### PR TITLE
Improved sanitization and formatting.

### DIFF
--- a/sanitize_html/CHANGELOG.md
+++ b/sanitize_html/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.2.0
+ * Does not depend on `universal_html`, uses custom HTML rendering for the output.
+ * Allowed classes are kept, even if there are non-allowed classes present on the same element.
+
 ## v1.1.0
  * Add options `allowElementId` and `allowClassName` to allow specific element
    ids and class names.

--- a/sanitize_html/lib/sanitize_html.dart
+++ b/sanitize_html/lib/sanitize_html.dart
@@ -14,15 +14,7 @@
 
 library sanitize_html;
 
-import 'dart:async' show Zone, ZoneDelegate, runZoned, ZoneSpecification;
 import 'src/sane_html_validator.dart' show SaneHtmlValidator;
-
-void _printHandler(Zone self, ZoneDelegate parent, Zone zone, String line) {
-  // Suppress printed lines about stuff being removed.
-  if (!line.startsWith('Removing disallowed')) {
-    parent.print(zone, line);
-  }
-}
 
 /// Sanitize [htmlString] to prevent XSS exploits and limit interference with
 /// other markup on the page.
@@ -60,10 +52,8 @@ String sanitizeHtml(
   bool Function(String) allowElementId,
   bool Function(String) allowClassName,
 }) {
-  return runZoned(() {
-    return SaneHtmlValidator(
-      allowElementId: allowElementId,
-      allowClassName: allowClassName,
-    ).sanitize(htmlString);
-  }, zoneSpecification: ZoneSpecification(print: _printHandler));
+  return SaneHtmlValidator(
+    allowElementId: allowElementId,
+    allowClassName: allowClassName,
+  ).sanitize(htmlString);
 }

--- a/sanitize_html/lib/sanitize_html.dart
+++ b/sanitize_html/lib/sanitize_html.dart
@@ -15,7 +15,6 @@
 library sanitize_html;
 
 import 'dart:async' show Zone, ZoneDelegate, runZoned, ZoneSpecification;
-import 'package:universal_html/html.dart' as html;
 import 'src/sane_html_validator.dart' show SaneHtmlValidator;
 
 void _printHandler(Zone self, ZoneDelegate parent, Zone zone, String line) {
@@ -61,14 +60,10 @@ String sanitizeHtml(
   bool Function(String) allowElementId,
   bool Function(String) allowClassName,
 }) {
-  final doc = runZoned(() {
-    return html.DocumentFragment.html(
-      htmlString,
-      validator: SaneHtmlValidator(
-        allowElementId: allowElementId,
-        allowClassName: allowClassName,
-      ),
-    );
+  return runZoned(() {
+    return SaneHtmlValidator(
+      allowElementId: allowElementId,
+      allowClassName: allowClassName,
+    ).sanitize(htmlString);
   }, zoneSpecification: ZoneSpecification(print: _printHandler));
-  return doc.innerHtml;
 }

--- a/sanitize_html/lib/src/html_formatter.dart
+++ b/sanitize_html/lib/src/html_formatter.dart
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:html/dom.dart';
+
+final _attrEscape = HtmlEscape(HtmlEscapeMode.attribute);
+final _textEscape = HtmlEscape(HtmlEscapeMode.unknown);
+
+String formatHtmlNode(Node node) {
+  return _HtmlFormatter()._format(node);
+}
+
+class _HtmlFormatter {
+  final _sb = StringBuffer();
+
+  String _format(Node node) {
+    _writeNodes([node], 0);
+    return _sb.toString();
+  }
+
+  void _writeNodes(List<Node> nodes, int level) {
+    if (nodes == null || nodes.isEmpty) return;
+    for (Node node in nodes) {
+      if (node is Element) {
+        _writeElement(node, level);
+      } else if (node is Text) {
+        _sb.write(_textEscape.convert(node.text));
+      } else if (node is Document) {
+        _writeNodes([node.documentElement], level);
+      } else if (node is DocumentFragment) {
+        _writeNodes(node.nodes, level);
+      } else {
+        throw UnimplementedError('Unknown node: ${node.runtimeType} ($node)');
+      }
+    }
+  }
+
+  void _writeElement(Element elem, int level) {
+    final tagName = elem.localName;
+    _sb.write('<$tagName');
+    elem.attributes.forEach((k, v) {
+      _sb.write(' $k="${_attrEscape.convert(v)}"');
+    });
+    if (elem.hasChildNodes()) {
+      _sb.write('>');
+      _writeNodes(elem.nodes, level + 1);
+      _sb.write('</$tagName>');
+    } else if (tagName.toLowerCase() == 'script') {
+      _sb.write('></$tagName>');
+    } else {
+      _sb.write(' />');
+    }
+  }
+}

--- a/sanitize_html/lib/src/html_formatter.dart
+++ b/sanitize_html/lib/src/html_formatter.dart
@@ -42,6 +42,10 @@ class _HtmlFormatter {
         _writeNodes([node.documentElement]);
       } else if (node is DocumentFragment) {
         _writeNodes(node.nodes);
+      } else if (node is Comment) {
+        // no output
+      } else if (node is DocumentType) {
+        // no output
       } else {
         throw UnimplementedError('Unknown node: ${node.runtimeType} ($node)');
       }

--- a/sanitize_html/lib/src/html_formatter.dart
+++ b/sanitize_html/lib/src/html_formatter.dart
@@ -17,7 +17,7 @@ import 'dart:convert';
 import 'package:html/dom.dart';
 
 final _attrEscape = HtmlEscape(HtmlEscapeMode.attribute);
-final _textEscape = HtmlEscape(HtmlEscapeMode.unknown);
+final _textEscape = HtmlEscape(HtmlEscapeMode.element);
 
 String formatHtmlNode(Node node) {
   return _HtmlFormatter()._format(node);

--- a/sanitize_html/lib/src/html_formatter.dart
+++ b/sanitize_html/lib/src/html_formatter.dart
@@ -27,28 +27,28 @@ class _HtmlFormatter {
   final _sb = StringBuffer();
 
   String _format(Node node) {
-    _writeNodes([node], 0);
+    _writeNodes([node]);
     return _sb.toString();
   }
 
-  void _writeNodes(List<Node> nodes, int level) {
+  void _writeNodes(List<Node> nodes) {
     if (nodes == null || nodes.isEmpty) return;
     for (Node node in nodes) {
       if (node is Element) {
-        _writeElement(node, level);
+        _writeElement(node);
       } else if (node is Text) {
         _sb.write(_textEscape.convert(node.text));
       } else if (node is Document) {
-        _writeNodes([node.documentElement], level);
+        _writeNodes([node.documentElement]);
       } else if (node is DocumentFragment) {
-        _writeNodes(node.nodes, level);
+        _writeNodes(node.nodes);
       } else {
         throw UnimplementedError('Unknown node: ${node.runtimeType} ($node)');
       }
     }
   }
 
-  void _writeElement(Element elem, int level) {
+  void _writeElement(Element elem) {
     final tagName = elem.localName;
     _sb.write('<$tagName');
     elem.attributes.forEach((k, v) {
@@ -56,7 +56,7 @@ class _HtmlFormatter {
     });
     if (elem.hasChildNodes()) {
       _sb.write('>');
-      _writeNodes(elem.nodes, level + 1);
+      _writeNodes(elem.nodes);
       _sb.write('</$tagName>');
     } else if (tagName.toLowerCase() == 'script') {
       _sb.write('></$tagName>');

--- a/sanitize_html/lib/src/html_formatter.dart
+++ b/sanitize_html/lib/src/html_formatter.dart
@@ -47,7 +47,8 @@ class _HtmlFormatter {
       } else if (node is DocumentType) {
         // no output
       } else {
-        throw UnimplementedError('Unknown node: ${node.runtimeType} ($node)');
+        // no output
+        assert(false);
       }
     }
   }

--- a/sanitize_html/lib/src/sane_html_validator.dart
+++ b/sanitize_html/lib/src/sane_html_validator.dart
@@ -247,6 +247,8 @@ class SaneHtmlValidator {
       });
     }
     if (node.hasChildNodes()) {
+      // doing it in reverse order, because we could otherwise skip one, when a
+      // node is removed...
       for (int i = node.nodes.length - 1; i >= 0; i--) {
         _sanitize(node.nodes[i]);
       }

--- a/sanitize_html/pubspec.yaml
+++ b/sanitize_html/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sanitize_html
-version: 1.1.0
+version: 1.2.0
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |
@@ -9,7 +9,7 @@ homepage: https://github.com/google/dart-neats/tree/master/sanitize_html
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:sanitize_html
 dependencies:
-  universal_html: ^0.1.0
+  html: '>=0.13.0 <0.15.0'
   meta: ^1.1.7
 dev_dependencies:
   test: ^1.5.1

--- a/sanitize_html/test/sanitize_html_test.dart
+++ b/sanitize_html/test/sanitize_html_test.dart
@@ -109,4 +109,6 @@ void main() {
   testContains('<br>', '<br />');
   testContains('><', '&gt;&lt;');
   testContains('<div><div id="x">a</div></div>', '<div><div>a</div></div>');
+  testContains('<a href="a.html">a</a><a href="b.html">b</a>',
+      '<a href="a.html">a</a><a href="b.html">b</a>');
 }

--- a/sanitize_html/test/sanitize_html_test.dart
+++ b/sanitize_html/test/sanitize_html_test.dart
@@ -56,6 +56,8 @@ void main() {
   testContains('<span class="only-allowed-class">hello</span>', 'class');
   testContains(
       '<span class="only-allowed-class">hello</span>', 'only-allowed-class');
+  testContains('<span class="only-allowed-class disallowed-class">hello</span>',
+      'class="only-allowed-class"');
   testNotContains('<span class="disallowed-class">hello</span>', 'class');
   testNotContains(
       '<span class="disallowed-class">hello</span>', 'only-allowed-class');
@@ -103,4 +105,8 @@ void main() {
   testNotContains('<form><input type="submit"/></form> click here', 'submit');
   testNotContains('<form><input type="submit"/></form> click here', 'input');
   testContains('<form><input type="submit"/></form> click here', 'click here');
+
+  testContains('<br>', '<br />');
+  testContains('><', '&gt;&lt;');
+  testContains('<div><div id="x">a</div></div>', '<div><div>a</div></div>');
 }


### PR DESCRIPTION
- fixes #2 
- no longer depends on `universal_html`:
- custom output formatting that keeps no-content tags as self-closing: `<img />`

I've wanted to create a separate library for the formatting (e.g. allow indents and a canonical formatting of the html markup), but the edges cases are hard to deal with, and I've settled with this simple solution.

The runZoned part could be probably removed? /cc @jonasfj 