### PR TITLE
Avoid unnecessary purge when .get(() => null) is called

### DIFF
--- a/neat_cache/CHANGELOG.md
+++ b/neat_cache/CHANGELOG.md
@@ -1,2 +1,6 @@
+## v1.0.1
+ * Avoid unnecessary purging when calling `set` with a `create` function that
+   returns `null`.
+
 ## v1.0.0
  * Initial release.

--- a/neat_cache/lib/neat_cache.dart
+++ b/neat_cache/lib/neat_cache.dart
@@ -172,7 +172,12 @@ class _Entry<T, V> implements Entry<T> {
       if (create == null) {
         return null;
       }
-      return await set(await create(), ttl);
+      final created = await create();
+      if (created != null) {
+        // Calling `set(null)` is equivalent to `purge()`, we can skip that here
+        await set(created, ttl);
+      }
+      return created;
     }
     return _owner._codec.decode(value);
   }

--- a/neat_cache/pubspec.yaml
+++ b/neat_cache/pubspec.yaml
@@ -1,5 +1,5 @@
 name: neat_cache
-version: 1.0.0
+version: 1.0.1
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |


### PR DESCRIPTION
I don't think there is any reasonable cases where you
will want to purge the cache from an _up-sert_ creator
callback.

Probably the `create` function returns `null` because
there is no value to be stored, and thus, nothing
should be cached.

Note. In generate `set(null)` will still call `purge()`.
Thus, `null` cannot be used to cache no-value.