### PR TITLE
Test that unrelated annotations does not affect code-gen

### DIFF
--- a/shelf_router_generator/test/server/service.dart
+++ b/shelf_router_generator/test/server/service.dart
@@ -16,6 +16,7 @@ import 'dart:async' show Future, FutureOr;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 import 'api.dart';
+import 'unrelatedannotation.dart';
 
 part 'service.g.dart';
 
@@ -50,4 +51,11 @@ class Service {
   Response _index(Request request) => Response.ok('nothing-here');
 
   Router get router => _$ServiceRouter(this);
+}
+
+class UnrelatedThing {
+  @EndPoint.put('/api/test')
+  Future<Response> unrelatedMethod(Request request) async {
+    return Response.ok('hello world');
+  }
 }

--- a/shelf_router_generator/test/server/unrelatedannotation.dart
+++ b/shelf_router_generator/test/server/unrelatedannotation.dart
@@ -1,0 +1,36 @@
+/// Annotation for an API end-point.
+class EndPoint {
+  /// HTTP verb for requests routed to the annotated method.
+  final String verb;
+
+  /// HTTP route for request routed to the annotated method.
+  final String route;
+
+  /// Create an annotation that routes requests matching [verb] and [route] to
+  /// the annotated method.
+  const EndPoint(this.verb, this.route);
+
+  /// Route `GET` requests matching [route] to annotated method.
+  const EndPoint.get(this.route) : verb = 'GET';
+
+  /// Route `HEAD` requests matching [route] to annotated method.
+  const EndPoint.head(this.route) : verb = 'HEAD';
+
+  /// Route `POST` requests matching [route] to annotated method.
+  const EndPoint.post(this.route) : verb = 'POST';
+
+  /// Route `PUT` requests matching [route] to annotated method.
+  const EndPoint.put(this.route) : verb = 'PUT';
+
+  /// Route `DELETE` requests matching [route] to annotated method.
+  const EndPoint.delete(this.route) : verb = 'DELETE';
+
+  /// Route `CONNECT` requests matching [route] to annotated method.
+  const EndPoint.connect(this.route) : verb = 'CONNECT';
+
+  /// Route `OPTIONS` requests matching [route] to annotated method.
+  const EndPoint.options(this.route) : verb = 'OPTIONS';
+
+  /// Route `TRACE` requests matching [route] to annotated method.
+  const EndPoint.trace(this.route) : verb = 'TRACE';
+}


### PR DESCRIPTION
Simple test that we don't generate code on unrelated annotations.