### PR TITLE
Workaround `ArgumentError.checkNotNull` regression in Dart 2.8.1

### DIFF
--- a/acyclic_steps/CHANGELOG.md
+++ b/acyclic_steps/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.10.1
+ * Added a workaround for `ArgumentError.checkNotNull` regression in Dart 2.8.1,
+   see [dartlang/sdk#41871](https://github.com/dart-lang/sdk/issues/41871).
+
 ## v0.10.0
  * **breaking** re-defined API for creating `Step`'s. The new fluent API ensures
    that the `runStep` method will infer correct types from generics. Due to low

--- a/acyclic_steps/lib/src/fluent_api.dart
+++ b/acyclic_steps/lib/src/fluent_api.dart
@@ -95,7 +95,11 @@ class Runner {
   Runner({
     RunStepWrapper wrapRunStep = _defaultRunStep,
   }) : _wrapRunStep = wrapRunStep {
-    ArgumentError.checkNotNull(wrapRunStep, 'runStep');
+    // Workaround Dart 2.8.1 regression reported in:
+    // https://github.com/dart-lang/sdk/issues/41871
+    if (wrapRunStep == null) {
+      throw ArgumentError.notNull('wrapRunStep');
+    }
   }
 
   /// Override [step] with [value], ensuring that [step] evaluates to [value]

--- a/acyclic_steps/pubspec.yaml
+++ b/acyclic_steps/pubspec.yaml
@@ -1,5 +1,5 @@
 name: acyclic_steps
-version: 0.10.0
+version: 0.10.1
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |


### PR DESCRIPTION
The issues is specific to generic type functions, and the workaround
seems very cheap with no impact on behavior.