### PR TITLE
fix retry overflow

### DIFF
--- a/retry/CHANGELOG.md
+++ b/retry/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v3.0.1+1
+## v3.0.1
  * Fix retry overflow
 
 ## v3.0.0+1

--- a/retry/CHANGELOG.md
+++ b/retry/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.0.1+1
+ * Fix retry overflow
+
 ## v3.0.0+1
  * Update the example in `README.md`.
 

--- a/retry/lib/retry.dart
+++ b/retry/lib/retry.dart
@@ -104,7 +104,8 @@ class RetryOptions {
       return Duration.zero;
     }
     final rf = (randomizationFactor * (_rand.nextDouble() * 2 - 1) + 1);
-    final delay = (delayFactor * math.pow(2.0, attempt) * rf);
+    final exp = math.min(attempt, 31); // prevent overflows.
+    final delay = (delayFactor * math.pow(2.0, exp) * rf);
     return delay < maxDelay ? delay : maxDelay;
   }
 

--- a/retry/lib/retry.dart
+++ b/retry/lib/retry.dart
@@ -104,7 +104,7 @@ class RetryOptions {
       return Duration.zero;
     }
     final rf = (randomizationFactor * (_rand.nextDouble() * 2 - 1) + 1);
-    final delay = (delayFactor * math.pow(2, attempt) * rf);
+    final delay = (delayFactor * math.pow(2.0, attempt) * rf);
     return delay < maxDelay ? delay : maxDelay;
   }
 

--- a/retry/pubspec.yaml
+++ b/retry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: retry
-version: 3.0.1+1
+version: 3.0.1
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |
@@ -12,5 +12,4 @@ dev_dependencies:
   test: ^1.5.1
   pedantic: ^1.4.0
 environment:
-  sdk: '>=2.0.0 <3.0.0'
-
+  sdk: ">=2.0.0 <3.0.0"

--- a/retry/pubspec.yaml
+++ b/retry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: retry
-version: 3.0.0+1
+version: 3.0.1+1
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |

--- a/retry/test/retry_test.dart
+++ b/retry/test/retry_test.dart
@@ -38,6 +38,11 @@ void main() {
       }
     });
 
+    test('avoid overflow', () {
+      final r = RetryOptions();
+      expect(r.delay(64), r.maxDelay);
+    });
+
     test('retry (success)', () async {
       int count = 0;
       final r = RetryOptions();


### PR DESCRIPTION
When I use retry with relatively big number of attempt (like 64), delay is overflow. It is because delay is calculated by int.

I change it to floating point so that it won't overflow. I added test also. 