### PR TITLE
Fixed ChunkedStreamIterator behavior when substream exactly completes a chunk.

### DIFF
--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,10 +1,17 @@
+## v1.1.1
+
+- Fixed `substream` behavior when the input length exactly completes a chunk.
+
 ## v1.1.0
- * Added `asChunkedStream(N, input)` for wrapping a `Stream<T>` as a
-   chunked stream `Stream<List<T>>`, which is useful when batch processing
-   chunks of a stream.
+
+- Added `asChunkedStream(N, input)` for wrapping a `Stream<T>` as a
+  chunked stream `Stream<List<T>>`, which is useful when batch processing
+  chunks of a stream.
 
 ## v1.0.1
- * Fixed lints reported by pana.
+
+- Fixed lints reported by pana.
 
 ## v1.0.0
- * Initial release.
+
+- Initial release.

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -201,7 +201,6 @@ class ChunkedStreamIterator<T> {
         return;
       }
     };
-    _wakeup();
 
     return c.stream;
   }

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chunked_stream
-version: 1.1.0
+version: 1.1.1
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |
@@ -12,5 +12,4 @@ dev_dependencies:
   test: ^1.5.1
   pedantic: ^1.4.0
 environment:
-  sdk: '>=2.0.0 <3.0.0'
-
+  sdk: ">=2.0.0 <3.0.0"

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -105,4 +105,16 @@ void main() {
     expect(await s.read(1), equals(['2']));
     expect(await s.read(1), equals([]));
   });
+
+  test(
+      'read() substream() that ends with first chunk + readChunkedStream() '
+      'read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(await s.read(1), equals(['a']));
+    expect(await readChunkedStream(s.substream(2)), equals(['b', 'c']));
+    expect(await s.read(3), equals(['1', '2']));
+  });
 }


### PR DESCRIPTION
Closes #62 