### PR TITLE
Chunked Stream Iterator update

### DIFF
--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,10 +1,18 @@
+## v1.2.0
+
+- Changed `ChunkedStreamIterator` implementation to fix bugs related to
+  stream pausing and resuming.
+
 ## v1.1.0
- * Added `asChunkedStream(N, input)` for wrapping a `Stream<T>` as a
-   chunked stream `Stream<List<T>>`, which is useful when batch processing
-   chunks of a stream.
+
+- Added `asChunkedStream(N, input)` for wrapping a `Stream<T>` as a
+  chunked stream `Stream<List<T>>`, which is useful when batch processing
+  chunks of a stream.
 
 ## v1.0.1
- * Fixed lints reported by pana.
+
+- Fixed lints reported by pana.
 
 ## v1.0.0
- * Initial release.
+
+- Initial release.

--- a/chunked_stream/example/main.dart
+++ b/chunked_stream/example/main.dart
@@ -46,7 +46,7 @@ void main() async {
 
   while (true) {
     // Read the first 4 bytes
-    final lengthBytes = await iterator.read(4);
+    final lengthBytes = await iterator.readAsBlock(4);
 
     // We have EOF if there is no more bytes
     if (lengthBytes.isEmpty) {

--- a/chunked_stream/example/main.dart
+++ b/chunked_stream/example/main.dart
@@ -46,7 +46,7 @@ void main() async {
 
   while (true) {
     // Read the first 4 bytes
-    final lengthBytes = await iterator.readAsBlock(4);
+    final lengthBytes = await iterator.read(4);
 
     // We have EOF if there is no more bytes
     if (lengthBytes.isEmpty) {

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -41,9 +41,6 @@ abstract class ChunkedStreamIterator<T> {
   /// Cancels the stream iterator (and the underlying stream subscription)
   /// early.
   ///
-  /// The [ChunkedStreamIterator] is automatically cancelled if [read] reaches
-  /// the end of the stream or an error.
-  ///
   /// Users should call [cancel] to ensure that the stream is properly closed
   /// if they need to stop listening earlier than the end of the stream.
   Future<void> cancel();
@@ -102,9 +99,6 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
   /// Cancels the stream iterator (and the underlying stream subscription)
   /// early.
-  ///
-  /// The [ChunkedStreamIterator] is automatically cancelled if [read]
-  /// reaches the end of the stream or an error.
   ///
   /// Users should call [cancel] to ensure that the stream is properly closed
   /// if they need to stop listening earlier than the end of the stream.

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -168,21 +168,21 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
     _toRead = size;
 
-    /// Creates a new [StreamController] made out of the elements from
-    /// [_iterator].
+    // Creates a new [StreamController] made out of the elements from
+    // [_iterator].
     final substream = _substream();
     final newController = StreamController<List<T>>();
 
-    /// When [newController]'s stream is cancelled, drain all the remaining
-    /// elements.
+    // When [newController]'s stream is cancelled, drain all the remaining
+    // elements.
     newController.onCancel = () async {
       await _substream().drain();
     };
 
-    /// Since the controller should only have [size] elements, we close
-    /// [newController]'s stream once all the elements in [substream] have
-    /// been added. This is necessary so that await-for loops on
-    /// [newController.stream] will complete.
+    // Since the controller should only have [size] elements, we close
+    // [newController]'s stream once all the elements in [substream] have
+    // been added. This is necessary so that await-for loops on
+    // [newController.stream] will complete.
     final future = newController.addStream(substream);
     future.whenComplete(() {
       newController.close();
@@ -193,10 +193,10 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
   /// Asynchronous generator implementation for [substream].
   Stream<List<T>> _substream() async* {
-    /// Only yield when there are elements to be read.
+    // Only yield when there are elements to be read.
     while (_toRead > 0) {
-      /// If [_buffered] is empty, set it to the next element in the stream if
-      /// possible.
+      // If [_buffered] is empty, set it to the next element in the stream if
+      // possible.
       if (_buffered.isEmpty) {
         if (!(await _iterator.moveNext())) {
           break;
@@ -207,14 +207,14 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
       List<T> toYield;
       if (_toRead < _buffered.length) {
-        /// If there are less than [_buffered.length] elements left to be read
-        /// in the substream, sublist the chunk from [_buffered] accordingly.
+        // If there are less than [_buffered.length] elements left to be read
+        // in the substream, sublist the chunk from [_buffered] accordingly.
         toYield = _buffered.sublist(0, _toRead);
         _buffered = _buffered.sublist(_toRead);
         _toRead = 0;
       } else {
-        /// Otherwise prepare to yield the full [_buffered] chunk, updating
-        /// the other variables accordingly
+        // Otherwise prepare to yield the full [_buffered] chunk, updating
+        // the other variables accordingly
         toYield = _buffered;
         _toRead -= _buffered.length;
         _buffered = _emptyList;
@@ -223,8 +223,8 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
       yield toYield;
     }
 
-    /// Set [_toRead] to be 0. This line is necessary if the size that is passed
-    /// in is greater than the number of elements in [_iterator].
+    // Set [_toRead] to be 0. This line is necessary if the size that is passed
+    // in is greater than the number of elements in [_iterator].
     _toRead = 0;
   }
 }

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -45,14 +45,36 @@ abstract class ChunkedStreamIterator<T> {
   /// if they need to stop listening earlier than the end of the stream.
   Future<void> cancel();
 
-  /// Creates a sub-[Stream] with the next [size] elements. At most one
-  /// sub-[Stream] should be present at one time.
+  /// Returns a sub-[Stream] with the next [size] elements.
   ///
-  /// The resulting stream may contain less than [size] elements if the
-  /// underlying stream has less than [size] elements before the end of stream.
+  /// A sub-[Stream] is a [Stream] consisting of the next [size] elements
+  /// in the same order they occur in the stream used to create this iterator.
   ///
   /// If [read] is called before the sub-[Stream] is fully read, a [StateError]
   /// will be thrown.
+  ///
+  /// ```dart
+  /// final s = ChunkedStreamIterator(_chunkedStream([
+  ///   ['a', 'b', 'c'],
+  ///   ['1', '2'],
+  /// ]));
+  /// expect(await s.read(1), equals(['a']));
+  ///
+  /// // creates a substream from the chunks holding the
+  /// // next three elements (['b', 'c'], ['1'])
+  /// final i = StreamIterator(s.substream(3));
+  /// expect(await i.moveNext(), isTrue);
+  /// expect(await i.current, equals(['b', 'c']));
+  /// expect(await i.moveNext(), isTrue);
+  /// expect(await i.current, equals(['1']));
+  ///
+  /// // Since the substream has been read till the end, we can continue reading
+  /// // from the initial stream.
+  /// expect(await s.read(1), equals(['2']));
+  /// ```
+  ///
+  /// The resulting stream may contain less than [size] elements if the
+  /// underlying stream has less than [size] elements before the end of stream.
   ///
   /// When the substream is cancelled, the remaining elements in the substream
   /// are drained.
@@ -105,14 +127,36 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
   @override
   Future<void> cancel() async => await _iterator.cancel();
 
-  /// Creates a sub-[Stream] with the next [size] elements. At most one
-  /// sub-[Stream] should be present at one time.
+  /// Returns a sub-[Stream] with the next [size] elements.
   ///
-  /// The resulting stream may contain less than [size] elements if the
-  /// underlying stream has less than [size] elements before the end of stream.
+  /// A sub-[Stream] is a [Stream] consisting of the next [size] elements
+  /// in the same order they occur in the stream used to create this iterator.
   ///
   /// If [read] is called before the sub-[Stream] is fully read, a [StateError]
   /// will be thrown.
+  ///
+  /// ```dart
+  /// final s = ChunkedStreamIterator(_chunkedStream([
+  ///   ['a', 'b', 'c'],
+  ///   ['1', '2'],
+  /// ]));
+  /// expect(await s.read(1), equals(['a']));
+  ///
+  /// // creates a substream from the chunks holding the
+  /// // next three elements (['b', 'c'], ['1'])
+  /// final i = StreamIterator(s.substream(3));
+  /// expect(await i.moveNext(), isTrue);
+  /// expect(await i.current, equals(['b', 'c']));
+  /// expect(await i.moveNext(), isTrue);
+  /// expect(await i.current, equals(['1']));
+  ///
+  /// // Since the substream has been read till the end, we can continue reading
+  /// // from the initial stream.
+  /// expect(await s.read(1), equals(['2']));
+  /// ```
+  ///
+  /// The resulting stream may contain less than [size] elements if the
+  /// underlying stream has less than [size] elements before the end of stream.
   ///
   /// When the substream is cancelled, the remaining elements in the substream
   /// are drained.

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -47,10 +47,11 @@ abstract class ChunkedStreamIterator<T> {
   /// will be thrown.
   Future<List<T>> read(int size);
 
-  /// Cancels the stream iterator (and the underlying stream subscription) early.
+  /// Cancels the stream iterator (and the underlying stream subscription)
+  /// early.
   ///
-  /// The [ChunkedStreamIterator] is automatically cancelled if [readPreservingChunks] goes
-  /// reaches the end of the stream or an error.
+  /// The [ChunkedStreamIterator] is automatically cancelled if [read] or
+  /// [readPreservingChunks] reaches the end of the stream or an error.
   ///
   /// Users should call [cancel] to ensure that the stream is properly closed
   /// if they need to stop listening earlier than the end of the stream.
@@ -61,8 +62,9 @@ abstract class ChunkedStreamIterator<T> {
   /// The resulting stream may contain less than [size] elements if the
   /// underlying stream has less than [size] elements before the end of stream.
   ///
-  /// If [readPreservingChunks] is called before the sub-[Stream] is fully read, the remainder
-  /// of the elements in the sub-[Stream] will be automatically drained.
+  /// If [read] or [readPreservingChunks] is called before the sub-[Stream] is
+  /// fully read, the remainder of the elements in the sub-[Stream] will be
+  /// automatically drained.
   Stream<List<T>> substream(int size);
 }
 
@@ -148,10 +150,11 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
         .toList();
   }
 
-  /// Cancels the stream iterator (and the underlying stream subscription) early.
+  /// Cancels the stream iterator (and the underlying stream subscription)
+  /// early.
   ///
-  /// The [ChunkedStreamIterator] is automatically cancelled if [readPreservingChunks] goes
-  /// reaches the end of the stream or an error.
+  /// The [ChunkedStreamIterator] is automatically cancelled if [read] or
+  /// [readPreservingChunks] reaches the end of the stream or an error.
   ///
   /// Users should call [cancel] to ensure that the stream is properly closed
   /// if they need to stop listening earlier than the end of the stream.
@@ -163,8 +166,9 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
   /// The resulting stream may contain less than [size] elements if the
   /// underlying stream has less than [size] elements before the end of stream.
   ///
-  /// If [readPreservingChunks] is called before the sub-[Stream] is fully read, the remainder
-  /// of the elements in the sub-[Stream] will be automatically drained.
+  /// If [read] or [readPreservingChunks] is called before the sub-[Stream] is
+  /// fully read, the remainder of the elements in the sub-[Stream] will be
+  /// automatically drained.
   @override
   Stream<List<T>> substream(int size) {
     _toRead = size;

--- a/chunked_stream/lib/src/read_chunked_stream.dart
+++ b/chunked_stream/lib/src/read_chunked_stream.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async' show Stream, Future;
 
-/// Read all chunks from [input] and return a list consistent of items from all
+/// Read all chunks from [input] and return a list consisting of items from all
 /// chunks.
 ///
 /// If the maximum number of items exceeded [maxSize] this will stop reading and

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chunked_stream
-version: 1.1.0
+version: 1.2.0
 authors:
   - Jonas Finnemann Jensen <jonasfj@google.com>
 description: |
@@ -12,5 +12,4 @@ dev_dependencies:
   test: ^1.5.1
   pedantic: ^1.4.0
 environment:
-  sdk: '>=2.0.0 <3.0.0'
-
+  sdk: ">=2.0.0 <3.0.0"

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -106,84 +106,6 @@ void main() {
     expect(await s.read(1), equals([]));
   });
 
-  test('readPreservingChunks() -- chunk in given size', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['a', 'b', 'c']
-        ]));
-    expect(
-        await s.readPreservingChunks(2),
-        equals([
-          ['1', '2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
-  });
-
-  test('readPreservingChunks() -- chunks one item at the time', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['b']
-        ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['c']
-        ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['1']
-        ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
-  });
-
-  test('readPreservingChunks() -- one big chunk', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.readPreservingChunks(6),
-        equals([
-          ['a', 'b', 'c'],
-          ['1', '2']
-        ]));
-  });
-
-  test('substream()', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.substream(5).toList(),
-        equals([
-          ['a', 'b', 'c'],
-          ['1', '2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
-  });
-
   test('substream() x 2', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
@@ -202,247 +124,122 @@ void main() {
         ]));
   });
 
-  test('substream() + readChunkedStream() -- past end', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.substream(6).toList(),
-        equals([
-          ['a', 'b', 'c'],
-          ['1', '2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
-  });
-
-  test('readPreservingChunks() substream() + readChunkedStream() read()',
-      () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
-    expect(
-        await s.substream(3).toList(),
-        equals([
-          ['b', 'c'],
-          ['1']
-        ]));
-    expect(
-        await s.readPreservingChunks(2),
-        equals([
-          ['2']
-        ]));
-  });
-
   test(
-      'readPreservingChunks() substream().cancel() read() -- one item at a '
-      'time', () async {
-    final s = ChunkedStreamIterator(_chunkedStream([
-      ['a', 'b', 'c'],
-      ['1', '2'],
-    ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
-    final i = StreamIterator(s.substream(3));
-    expect(await i.moveNext(), isTrue);
-    await i.cancel();
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
-  });
-
-  test(
-      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'read() substream().cancel() read() -- '
       'cancellation without reading', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final i = StreamIterator(s.substream(3));
     await i.cancel();
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['2']
-        ]));
-    expect(await s.readPreservingChunks(1), equals([]));
+    expect(await s.read(1), equals(['2']));
+    expect(await s.read(1), equals([]));
   });
 
   test(
-      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'read() substream().cancel() read() -- '
       'not cancelling still produces correct behavior', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final i = StreamIterator(s.substream(3));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['2']
-        ]));
+    expect(await s.read(1), equals(['2']));
     expect(await i.moveNext(), false);
-    expect(await s.readPreservingChunks(1), equals([]));
+    expect(await s.read(1), equals([]));
   });
 
   test(
-      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'read() substream().cancel() read() -- '
       'not cancelling still produces correct behavior (2)', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2', '3'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final i = StreamIterator(s.substream(2));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['1']
-        ]));
+    expect(await s.read(1), equals(['1']));
     // ignore: unused_local_variable
     final i2 = StreamIterator(s.substream(2));
     expect(await i.moveNext(), false);
-    expect(await s.readPreservingChunks(1), equals([]));
+    expect(await s.read(1), equals([]));
   });
 
   test(
-      'readPreservingChunks() substream() that ends with first chunk + '
-      'readChunkedStream() readPreservingChunks()', () async {
+      'read() substream() that ends with first chunk + '
+      'readChunkedStream() read()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     expect(
         await s.substream(2).toList(),
         equals([
           ['b', 'c']
         ]));
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['1', '2']
-        ]));
+    expect(await s.read(3), equals(['1', '2']));
   });
 
   test(
-      'readPreservingChunks() substream() that ends with first chunk + drain() '
-      'readPreservingChunks()', () async {
+      'read() substream() that ends with first chunk + drain() '
+      'read()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final sub = s.substream(2);
     await sub.drain();
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['1', '2']
-        ]));
+    expect(await s.read(3), equals(['1', '2']));
   });
 
   test(
-      'readPreservingChunks() substream() that ends with second chunk + '
-      'readChunkedStream() readPreservingChunks()', () async {
+      'read() substream() that ends with second chunk + '
+      'readChunkedStream() read()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4']
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     expect(
         await s.substream(4).toList(),
         equals([
           ['b', 'c'],
           ['1', '2']
         ]));
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['3', '4']
-        ]));
+    expect(await s.read(3), equals(['3', '4']));
   });
 
   test(
-      'readPreservingChunks() substream() that ends with second chunk + '
-      'drain() readPreservingChunks()', () async {
+      'read() substream() that ends with second chunk + '
+      'drain() read()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final substream = s.substream(4);
     await substream.drain();
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['3', '4']
-        ]));
+    expect(await s.read(3), equals(['3', '4']));
   });
 
   test(
-      'readPreservingChunks() substream() readPreservingChunks() before '
+      'read() substream() read() before '
       'draining substream', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final substream = s.substream(4);
-    expect(
-        await s.readPreservingChunks(3),
-        equals([
-          ['3', '4']
-        ]));
+    expect(await s.read(3), equals(['3', '4']));
     expect(await substream.length, 0);
   });
 
@@ -452,30 +249,12 @@ void main() {
       ['1', '2'],
       ['3', '4'],
     ]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['a']
-        ]));
+    expect(await s.read(1), equals(['a']));
     final substream = s.substream(4);
     final nested = ChunkedStreamIterator(substream);
-    expect(
-        await nested.readPreservingChunks(2),
-        equals([
-          ['b'],
-          ['1']
-        ]));
-    expect(
-        await nested.readPreservingChunks(3),
-        equals([
-          ['2'],
-          ['3']
-        ]));
-    expect(await nested.readPreservingChunks(2), equals([]));
-    expect(
-        await s.readPreservingChunks(1),
-        equals([
-          ['4']
-        ]));
+    expect(await nested.read(2), equals(['b', '1']));
+    expect(await nested.read(3), equals(['2', '3']));
+    expect(await nested.read(2), equals([]));
+    expect(await s.read(1), equals(['4']));
   });
 }

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -160,6 +160,7 @@ void main() {
     expect(await i.current, equals(['b', 'c']));
     expect(await i.moveNext(), isTrue);
     expect(await i.current, equals(['1']));
+    expect(await i.moveNext(), isFalse);
     expect(await s.read(1), equals(['2']));
     expect(await s.read(1), equals([]));
   });

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -23,35 +23,35 @@ Stream<List<T>> _chunkedStream<T>(List<List<T>> chunks) async* {
 }
 
 void main() {
-  test('readAsBlock() -- chunk in given size', () async {
+  test('read() -- chunk in given size', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.readAsBlock(3), equals(['a', 'b', 'c']));
-    expect(await s.readAsBlock(2), equals(['1', '2']));
-    expect(await s.readAsBlock(1), equals([]));
+    expect(await s.read(3), equals(['a', 'b', 'c']));
+    expect(await s.read(2), equals(['1', '2']));
+    expect(await s.read(1), equals([]));
   });
 
-  test('readAsBlock() -- chunks one item at the time', () async {
+  test('read() -- chunks one item at the time', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.readAsBlock(1), equals(['a']));
-    expect(await s.readAsBlock(1), equals(['b']));
-    expect(await s.readAsBlock(1), equals(['c']));
-    expect(await s.readAsBlock(1), equals(['1']));
-    expect(await s.readAsBlock(1), equals(['2']));
-    expect(await s.readAsBlock(1), equals([]));
+    expect(await s.read(1), equals(['a']));
+    expect(await s.read(1), equals(['b']));
+    expect(await s.read(1), equals(['c']));
+    expect(await s.read(1), equals(['1']));
+    expect(await s.read(1), equals(['2']));
+    expect(await s.read(1), equals([]));
   });
 
-  test('readAsBlock() -- one big chunk', () async {
+  test('read() -- one big chunk', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.readAsBlock(6), equals(['a', 'b', 'c', '1', '2']));
+    expect(await s.read(6), equals(['a', 'b', 'c', '1', '2']));
   });
 
   test('substream() + readChunkedStream()', () async {
@@ -61,7 +61,7 @@ void main() {
     ]));
     expect(await readChunkedStream(s.substream(5)),
         equals(['a', 'b', 'c', '1', '2']));
-    expect(await s.readAsBlock(1), equals([]));
+    expect(await s.read(1), equals([]));
   });
 
   test('substream() + readChunkedStream() x 2', () async {
@@ -80,93 +80,90 @@ void main() {
     ]));
     expect(await readChunkedStream(s.substream(6)),
         equals(['a', 'b', 'c', '1', '2']));
-    expect(await s.readAsBlock(1), equals([]));
+    expect(await s.read(1), equals([]));
   });
 
-  test('readAsBlock() substream() + readChunkedStream() readAsBlock()',
-      () async {
+  test('read() substream() + readChunkedStream() read()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.readAsBlock(1), equals(['a']));
+    expect(await s.read(1), equals(['a']));
     expect(await readChunkedStream(s.substream(3)), equals(['b', 'c', '1']));
-    expect(await s.readAsBlock(2), equals(['2']));
+    expect(await s.read(2), equals(['2']));
   });
 
-  test(
-      'readAsBlock() substream().cancel() readAsBlock() -- one item at the time',
-      () async {
+  test('read() substream().cancel() read() -- one item at the time', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.readAsBlock(1), equals(['a']));
+    expect(await s.read(1), equals(['a']));
     final i = StreamIterator(s.substream(3));
     expect(await i.moveNext(), isTrue);
     await i.cancel();
-    expect(await s.readAsBlock(1), equals(['2']));
-    expect(await s.readAsBlock(1), equals([]));
+    expect(await s.read(1), equals(['2']));
+    expect(await s.read(1), equals([]));
   });
 
-  test('read() -- chunk in given size', () async {
+  test('readPreservingChunks() -- chunk in given size', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['a', 'b', 'c']
         ]));
     expect(
-        await s.read(2),
+        await s.readPreservingChunks(2),
         equals([
           ['1', '2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
-  test('read() -- chunks one item at the time', () async {
+  test('readPreservingChunks() -- chunks one item at the time', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['b']
         ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['c']
         ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['1']
         ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
-  test('read() -- one big chunk', () async {
+  test('readPreservingChunks() -- one big chunk', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(6),
+        await s.readPreservingChunks(6),
         equals([
           ['a', 'b', 'c'],
           ['1', '2']
@@ -184,7 +181,7 @@ void main() {
           ['a', 'b', 'c'],
           ['1', '2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
   test('substream() x 2', () async {
@@ -216,16 +213,17 @@ void main() {
           ['a', 'b', 'c'],
           ['1', '2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
-  test('read() substream() + readChunkedStream() read()', () async {
+  test('readPreservingChunks() substream() + readChunkedStream() read()',
+      () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
@@ -236,19 +234,21 @@ void main() {
           ['1']
         ]));
     expect(
-        await s.read(2),
+        await s.readPreservingChunks(2),
         equals([
           ['2']
         ]));
   });
 
-  test('read() substream().cancel() read() -- one item at the time', () async {
+  test(
+      'readPreservingChunks() substream().cancel() read() -- one item at a '
+      'time', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
@@ -256,89 +256,90 @@ void main() {
     expect(await i.moveNext(), isTrue);
     await i.cancel();
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
-  test('read() substream().cancel() read() -- cancellation without reading',
-      () async {
+  test(
+      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'cancellation without reading', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final i = StreamIterator(s.substream(3));
     await i.cancel();
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['2']
         ]));
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
   test(
-      'read() substream().cancel() read() -- not cancelling still produces '
-      'correct behavior', () async {
+      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'not cancelling still produces correct behavior', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final i = StreamIterator(s.substream(3));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['2']
         ]));
     expect(await i.moveNext(), false);
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
   test(
-      'read() substream().cancel() read() -- not cancelling still produces '
-      'correct behavior (2)', () async {
+      'readPreservingChunks() substream().cancel() readPreservingChunks() -- '
+      'not cancelling still produces correct behavior (2)', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2', '3'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final i = StreamIterator(s.substream(2));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['1']
         ]));
     // ignore: unused_local_variable
     final i2 = StreamIterator(s.substream(2));
     expect(await i.moveNext(), false);
-    expect(await s.read(1), equals([]));
+    expect(await s.readPreservingChunks(1), equals([]));
   });
 
   test(
-      'read() substream() that ends with first chunk + readChunkedStream() '
-      'read()', () async {
+      'readPreservingChunks() substream() that ends with first chunk + '
+      'readChunkedStream() readPreservingChunks()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
@@ -348,43 +349,43 @@ void main() {
           ['b', 'c']
         ]));
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['1', '2']
         ]));
   });
 
   test(
-      'read() substream() that ends with first chunk + drain() '
-      'read()', () async {
+      'readPreservingChunks() substream() that ends with first chunk + drain() '
+      'readPreservingChunks()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final sub = s.substream(2);
     await sub.drain();
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['1', '2']
         ]));
   });
 
   test(
-      'read() substream() that ends with second chunk + readChunkedStream() '
-      'read()', () async {
+      'readPreservingChunks() substream() that ends with second chunk + '
+      'readChunkedStream() readPreservingChunks()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4']
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
@@ -395,48 +396,50 @@ void main() {
           ['1', '2']
         ]));
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['3', '4']
         ]));
   });
 
   test(
-      'read() substream() that ends with second chunk + drain() '
-      'read()', () async {
+      'readPreservingChunks() substream() that ends with second chunk + '
+      'drain() readPreservingChunks()', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final substream = s.substream(4);
     await substream.drain();
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['3', '4']
         ]));
   });
 
-  test('read() substream() read() before draining substream', () async {
+  test(
+      'readPreservingChunks() substream() readPreservingChunks() before '
+      'draining substream', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
       ['3', '4'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final substream = s.substream(4);
     expect(
-        await s.read(3),
+        await s.readPreservingChunks(3),
         equals([
           ['3', '4']
         ]));
@@ -450,27 +453,27 @@ void main() {
       ['3', '4'],
     ]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['a']
         ]));
     final substream = s.substream(4);
     final nested = ChunkedStreamIterator(substream);
     expect(
-        await nested.read(2),
+        await nested.readPreservingChunks(2),
         equals([
           ['b'],
           ['1']
         ]));
     expect(
-        await nested.read(3),
+        await nested.readPreservingChunks(3),
         equals([
           ['2'],
           ['3']
         ]));
-    expect(await nested.read(2), equals([]));
+    expect(await nested.readPreservingChunks(2), equals([]));
     expect(
-        await s.read(1),
+        await s.readPreservingChunks(1),
         equals([
           ['4']
         ]));

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -108,4 +108,371 @@ void main() {
     expect(await s.readAsBlock(1), equals(['2']));
     expect(await s.readAsBlock(1), equals([]));
   });
+
+  test('read() -- chunk in given size', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(3),
+        equals([
+          ['a', 'b', 'c']
+        ]));
+    expect(
+        await s.read(2),
+        equals([
+          ['1', '2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test('read() -- chunks one item at the time', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['b']
+        ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['c']
+        ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['1']
+        ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test('read() -- one big chunk', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(6),
+        equals([
+          ['a', 'b', 'c'],
+          ['1', '2']
+        ]));
+  });
+
+  test('substream()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.substream(5).toList(),
+        equals([
+          ['a', 'b', 'c'],
+          ['1', '2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test('substream() x 2', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.substream(2).toList(),
+        equals([
+          ['a', 'b']
+        ]));
+    expect(
+        await s.substream(3).toList(),
+        equals([
+          ['c'],
+          ['1', '2']
+        ]));
+  });
+
+  test('substream() + readChunkedStream() -- past end', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.substream(6).toList(),
+        equals([
+          ['a', 'b', 'c'],
+          ['1', '2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test('read() substream() + readChunkedStream() read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    expect(
+        await s.substream(3).toList(),
+        equals([
+          ['b', 'c'],
+          ['1']
+        ]));
+    expect(
+        await s.read(2),
+        equals([
+          ['2']
+        ]));
+  });
+
+  test('read() substream().cancel() read() -- one item at the time', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final i = StreamIterator(s.substream(3));
+    expect(await i.moveNext(), isTrue);
+    await i.cancel();
+    expect(
+        await s.read(1),
+        equals([
+          ['2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test('read() substream().cancel() read() -- cancellation without reading',
+      () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final i = StreamIterator(s.substream(3));
+    await i.cancel();
+    expect(
+        await s.read(1),
+        equals([
+          ['2']
+        ]));
+    expect(await s.read(1), equals([]));
+  });
+
+  test(
+      'read() substream().cancel() read() -- not cancelling still produces '
+      'correct behavior', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final i = StreamIterator(s.substream(3));
+    expect(
+        await s.read(1),
+        equals([
+          ['2']
+        ]));
+    expect(await i.moveNext(), false);
+    expect(await s.read(1), equals([]));
+  });
+
+  test(
+      'read() substream().cancel() read() -- not cancelling still produces '
+      'correct behavior (2)', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2', '3'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final i = StreamIterator(s.substream(2));
+    expect(
+        await s.read(1),
+        equals([
+          ['1']
+        ]));
+    // ignore: unused_local_variable
+    final i2 = StreamIterator(s.substream(2));
+    expect(await i.moveNext(), false);
+    expect(await s.read(1), equals([]));
+  });
+
+  test(
+      'read() substream() that ends with first chunk + readChunkedStream() '
+      'read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    expect(
+        await s.substream(2).toList(),
+        equals([
+          ['b', 'c']
+        ]));
+    expect(
+        await s.read(3),
+        equals([
+          ['1', '2']
+        ]));
+  });
+
+  test(
+      'read() substream() that ends with first chunk + drain() '
+      'read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final sub = s.substream(2);
+    await sub.drain();
+    expect(
+        await s.read(3),
+        equals([
+          ['1', '2']
+        ]));
+  });
+
+  test(
+      'read() substream() that ends with second chunk + readChunkedStream() '
+      'read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+      ['3', '4']
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    expect(
+        await s.substream(4).toList(),
+        equals([
+          ['b', 'c'],
+          ['1', '2']
+        ]));
+    expect(
+        await s.read(3),
+        equals([
+          ['3', '4']
+        ]));
+  });
+
+  test(
+      'read() substream() that ends with second chunk + drain() '
+      'read()', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+      ['3', '4'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final substream = s.substream(4);
+    await substream.drain();
+    expect(
+        await s.read(3),
+        equals([
+          ['3', '4']
+        ]));
+  });
+
+  test('read() substream() read() before draining substream', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b', 'c'],
+      ['1', '2'],
+      ['3', '4'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final substream = s.substream(4);
+    expect(
+        await s.read(3),
+        equals([
+          ['3', '4']
+        ]));
+    expect(await substream.length, 0);
+  });
+
+  test('nested ChunkedStreamIterator', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      ['a', 'b'],
+      ['1', '2'],
+      ['3', '4'],
+    ]));
+    expect(
+        await s.read(1),
+        equals([
+          ['a']
+        ]));
+    final substream = s.substream(4);
+    final nested = ChunkedStreamIterator(substream);
+    expect(
+        await nested.read(2),
+        equals([
+          ['b'],
+          ['1']
+        ]));
+    expect(
+        await nested.read(3),
+        equals([
+          ['2'],
+          ['3']
+        ]));
+    expect(await nested.read(2), equals([]));
+    expect(
+        await s.read(1),
+        equals([
+          ['4']
+        ]));
+  });
 }

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -214,11 +214,11 @@ void main() {
     expect(await s.read(1), equals(['6']));
   });
 
-  /// The following test fails because before the first `moveNext` is called,
-  /// the [StreamIterator] is not intialized to the correct
-  /// [StreamSubscription], thus calling `cancel` does not correctly cancel the
-  /// underlying stream, resulting in an error.
-  ///
+  // The following test fails because before the first `moveNext` is called,
+  // the [StreamIterator] is not intialized to the correct
+  // [StreamSubscription], thus calling `cancel` does not correctly cancel the
+  // underlying stream, resulting in an error.
+  //
   // test(
   //     'read() substream().cancel() read() -- '
   //     'cancellation without reading', () async {

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -23,35 +23,35 @@ Stream<List<T>> _chunkedStream<T>(List<List<T>> chunks) async* {
 }
 
 void main() {
-  test('read() -- chunk in given size', () async {
+  test('readAsBlock() -- chunk in given size', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.read(3), equals(['a', 'b', 'c']));
-    expect(await s.read(2), equals(['1', '2']));
-    expect(await s.read(1), equals([]));
+    expect(await s.readAsBlock(3), equals(['a', 'b', 'c']));
+    expect(await s.readAsBlock(2), equals(['1', '2']));
+    expect(await s.readAsBlock(1), equals([]));
   });
 
-  test('read() -- chunks one item at the time', () async {
+  test('readAsBlock() -- chunks one item at the time', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.read(1), equals(['a']));
-    expect(await s.read(1), equals(['b']));
-    expect(await s.read(1), equals(['c']));
-    expect(await s.read(1), equals(['1']));
-    expect(await s.read(1), equals(['2']));
-    expect(await s.read(1), equals([]));
+    expect(await s.readAsBlock(1), equals(['a']));
+    expect(await s.readAsBlock(1), equals(['b']));
+    expect(await s.readAsBlock(1), equals(['c']));
+    expect(await s.readAsBlock(1), equals(['1']));
+    expect(await s.readAsBlock(1), equals(['2']));
+    expect(await s.readAsBlock(1), equals([]));
   });
 
-  test('read() -- one big chunk', () async {
+  test('readAsBlock() -- one big chunk', () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.read(6), equals(['a', 'b', 'c', '1', '2']));
+    expect(await s.readAsBlock(6), equals(['a', 'b', 'c', '1', '2']));
   });
 
   test('substream() + readChunkedStream()', () async {
@@ -61,7 +61,7 @@ void main() {
     ]));
     expect(await readChunkedStream(s.substream(5)),
         equals(['a', 'b', 'c', '1', '2']));
-    expect(await s.read(1), equals([]));
+    expect(await s.readAsBlock(1), equals([]));
   });
 
   test('substream() + readChunkedStream() x 2', () async {
@@ -80,29 +80,32 @@ void main() {
     ]));
     expect(await readChunkedStream(s.substream(6)),
         equals(['a', 'b', 'c', '1', '2']));
-    expect(await s.read(1), equals([]));
+    expect(await s.readAsBlock(1), equals([]));
   });
 
-  test('read() substream() + readChunkedStream() read()', () async {
+  test('readAsBlock() substream() + readChunkedStream() readAsBlock()',
+      () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.read(1), equals(['a']));
+    expect(await s.readAsBlock(1), equals(['a']));
     expect(await readChunkedStream(s.substream(3)), equals(['b', 'c', '1']));
-    expect(await s.read(2), equals(['2']));
+    expect(await s.readAsBlock(2), equals(['2']));
   });
 
-  test('read() substream().cancel() read() -- one item at the time', () async {
+  test(
+      'readAsBlock() substream().cancel() readAsBlock() -- one item at the time',
+      () async {
     final s = ChunkedStreamIterator(_chunkedStream([
       ['a', 'b', 'c'],
       ['1', '2'],
     ]));
-    expect(await s.read(1), equals(['a']));
+    expect(await s.readAsBlock(1), equals(['a']));
     final i = StreamIterator(s.substream(3));
     expect(await i.moveNext(), isTrue);
     await i.cancel();
-    expect(await s.read(1), equals(['2']));
-    expect(await s.read(1), equals([]));
+    expect(await s.readAsBlock(1), equals(['2']));
+    expect(await s.readAsBlock(1), equals([]));
   });
 }


### PR DESCRIPTION
Updated the implementation of `ChunkedStreamIterator` to fix bugs raised in previous issues. As far as I can tell, the public API still stays the same, so it shouldn't be a breaking change I think?

Closes #66 
Closes #62 

/cc @jonasfj 