### PR TITLE
Migrate chunked_stream to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,16 @@ jobs:
       env: PKGS="acyclic_steps canonical_json chunked_stream http_methods neat_cache neat_periodic_task pem retry safe_url_check sanitize_html shelf_router shelf_router_generator slugid yaml_edit"
       script: tool/travis.sh dartfmt
     - stage: analyze
-      name: "SDK: stable; PKGS: acyclic_steps, canonical_json, chunked_stream, http_methods, neat_cache, neat_periodic_task, pem, safe_url_check, sanitize_html, shelf_router, shelf_router_generator, slugid, yaml_edit; TASKS: `dartanalyzer .`"
+      name: "SDK: stable; PKGS: acyclic_steps, canonical_json, http_methods, neat_cache, neat_periodic_task, pem, safe_url_check, sanitize_html, shelf_router, shelf_router_generator, slugid, yaml_edit; TASKS: `dartanalyzer .`"
       dart: stable
       os: linux
-      env: PKGS="acyclic_steps canonical_json chunked_stream http_methods neat_cache neat_periodic_task pem safe_url_check sanitize_html shelf_router shelf_router_generator slugid yaml_edit"
+      env: PKGS="acyclic_steps canonical_json http_methods neat_cache neat_periodic_task pem safe_url_check sanitize_html shelf_router shelf_router_generator slugid yaml_edit"
       script: tool/travis.sh dartanalyzer
     - stage: analyze
-      name: "SDK: stable; PKGS: acyclic_steps, canonical_json, chunked_stream, http_methods, neat_cache, neat_periodic_task, pem, safe_url_check, sanitize_html, shelf_router, shelf_router_generator, slugid, yaml_edit; TASKS: `dartfmt -n --set-exit-if-changed .`"
+      name: "SDK: stable; PKGS: acyclic_steps, canonical_json, http_methods, neat_cache, neat_periodic_task, pem, safe_url_check, sanitize_html, shelf_router, shelf_router_generator, slugid, yaml_edit; TASKS: `dartfmt -n --set-exit-if-changed .`"
       dart: stable
       os: linux
-      env: PKGS="acyclic_steps canonical_json chunked_stream http_methods neat_cache neat_periodic_task pem safe_url_check sanitize_html shelf_router shelf_router_generator slugid yaml_edit"
+      env: PKGS="acyclic_steps canonical_json http_methods neat_cache neat_periodic_task pem safe_url_check sanitize_html shelf_router shelf_router_generator slugid yaml_edit"
       script: tool/travis.sh dartfmt
     - stage: tests
       name: "SDK: dev; PKG: acyclic_steps; TASKS: `pub run test`"
@@ -64,12 +64,6 @@ jobs:
     - stage: tests
       name: "SDK: dev; PKG: chunked_stream; TASKS: `pub run test`"
       dart: dev
-      os: linux
-      env: PKGS="chunked_stream"
-      script: tool/travis.sh test
-    - stage: tests
-      name: "SDK: stable; PKG: chunked_stream; TASKS: `pub run test`"
-      dart: stable
       os: linux
       env: PKGS="chunked_stream"
       script: tool/travis.sh test

--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.0-nullsafety.0
+
+- Migated to null safety
+
 ## v1.2.0
 
 - Changed `ChunkedStreamIterator` implementation to fix bugs related to

--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.3.0-nullsafety.0
 
-- Migated to null safety
+- Migrated to null safety
 
 ## v1.2.0
 

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -91,7 +91,7 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
   /// Buffered items from a previous chunk. Items in this list should not have
   /// been read by the user.
-  List<T> _buffered;
+  late List<T> _buffered;
 
   /// Instance variable representing an empty list object, used as the empty
   /// default state for [_buffered]. Take caution not to write code that

--- a/chunked_stream/lib/src/read_chunked_stream.dart
+++ b/chunked_stream/lib/src/read_chunked_stream.dart
@@ -32,7 +32,7 @@ import 'dart:async' show Stream, Future;
 /// ```
 Future<List<T>> readChunkedStream<T>(
   Stream<List<T>> input, {
-  int maxSize,
+  int? maxSize,
 }) async {
   ArgumentError.checkNotNull(input, 'input');
   if (maxSize != null && maxSize < 0) {
@@ -54,7 +54,7 @@ Future<List<T>> readChunkedStream<T>(
 /// Throws [MaximumSizeExceeded] if [input] contains more than [maxSize] items.
 Stream<List<T>> limitChunkedStream<T>(
   Stream<List<T>> input, {
-  int maxSize,
+  int? maxSize,
 }) async* {
   ArgumentError.checkNotNull(input, 'input');
   if (maxSize != null && maxSize < 0) {

--- a/chunked_stream/mono_pkg.yaml
+++ b/chunked_stream/mono_pkg.yaml
@@ -1,5 +1,6 @@
 dart:
-  - stable
+# todo: Uncomment once Dart 2.12 is stable
+#  - stable
   - dev
 stages:
   - analyze:

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chunked_stream
-version: 1.2.0
+version: 1.3.0-nullsafety.0
 description: |
   Utilities for working with chunked streams, such as byte streams which is
   often given as a stream of byte chunks with type `Stream<List<int>>`.
@@ -7,7 +7,7 @@ homepage: https://github.com/google/dart-neats/tree/master/chunked_stream
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:chunked_stream
 dev_dependencies:
-  test: ^1.5.1
+  test: ^1.16.0-nullsafety
   pedantic: ^1.4.0
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"


### PR DESCRIPTION
Migrates the `chunked_stream` package to null safety. I kept the `ArgumentError.notNull` guards to support weak null-safety.