### PR TITLE
Support custom buffers in chunked_stream

### DIFF
--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.0-nullsafety.1
+
+- Support custom buffer implementations via the `newBuffer` parameter
+
 ## v1.3.0-nullsafety.0
 
 - Migrated to null safety

--- a/chunked_stream/lib/chunked_stream.dart
+++ b/chunked_stream/lib/chunked_stream.dart
@@ -34,6 +34,7 @@ import 'src/chunked_stream_buffer.dart';
 import 'src/chunked_stream_iterator.dart';
 import 'src/read_chunked_stream.dart';
 
+export 'src/buffer_factory.dart';
 export 'src/chunk_stream.dart';
 export 'src/chunked_stream_buffer.dart';
 export 'src/chunked_stream_iterator.dart';

--- a/chunked_stream/lib/src/buffer_factory.dart
+++ b/chunked_stream/lib/src/buffer_factory.dart
@@ -1,0 +1,28 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Signature of a function creating a buffer.
+///
+/// The buffer returned must be growable.
+///
+/// Depending on the input stream to buffer, a custom [BufferFactory] can be
+/// provided to improve memory efficiency. For instance, a [Uint8Buffer][uib]
+/// from the `typed_data` package can be suitable when operating on byte-
+/// streams.
+///
+/// When no custom [BufferFactory] is provided, this package will use the
+/// default [List] implementation.
+///
+/// [uib]: https://pub.dev/documentation/typed_data/latest/typed_data.typed_buffers/Uint8Buffer-class.html
+typedef BufferFactory<T> = List<T> Function();

--- a/chunked_stream/lib/src/chunked_stream_iterator.dart
+++ b/chunked_stream/lib/src/chunked_stream_iterator.dart
@@ -99,17 +99,16 @@ class _ChunkedStreamIterator<T> implements ChunkedStreamIterator<T> {
 
   /// Buffered items from a previous chunk. Items in this list should not have
   /// been read by the user.
-  late List<T> _buffered;
+  List<T> _buffered;
 
-  /// Instance variable representing an empty list object, used as the empty
-  /// default state for [_buffered]. Take caution not to write code that
-  /// directly modify the [_buffered] list by adding elements to it.
-  List<T> get _emptyList => const <Never>[];
+  /// Empty list. used as the empty default state for [_buffered]. Take caution
+  /// not to write code that directly modify the [_buffered] list by adding
+  /// elements to it.
+  static const _emptyList = <Never>[];
 
   _ChunkedStreamIterator(Stream<List<T>> stream, this._newBuffer)
-      : _iterator = StreamIterator(stream) {
-    _buffered = _emptyList;
-  }
+      : _iterator = StreamIterator(stream),
+        _buffered = _emptyList;
 
   /// Returns a list of the next [size] elements.
   ///

--- a/chunked_stream/lib/src/read_chunked_stream.dart
+++ b/chunked_stream/lib/src/read_chunked_stream.dart
@@ -14,6 +14,8 @@
 
 import 'dart:async' show Stream, Future;
 
+import 'buffer_factory.dart';
+
 /// Read all chunks from [input] and return a list consisting of items from all
 /// chunks.
 ///
@@ -33,13 +35,14 @@ import 'dart:async' show Stream, Future;
 Future<List<T>> readChunkedStream<T>(
   Stream<List<T>> input, {
   int? maxSize,
+  BufferFactory<T>? newBuffer,
 }) async {
   ArgumentError.checkNotNull(input, 'input');
   if (maxSize != null && maxSize < 0) {
     throw ArgumentError.value(maxSize, 'maxSize must be positive, if given');
   }
 
-  final result = <T>[];
+  final result = newBuffer?.call() ?? <T>[];
   await for (final chunk in input) {
     result.addAll(chunk);
     if (maxSize != null && result.length > maxSize) {

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chunked_stream
-version: 1.3.0-nullsafety.0
+version: 1.3.0-nullsafety.1
 description: |
   Utilities for working with chunked streams, such as byte streams which is
   often given as a stream of byte chunks with type `Stream<List<int>>`.
@@ -8,6 +8,7 @@ repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:chunked_stream
 dev_dependencies:
   test: ^1.16.0-nullsafety
+  typed_data: ^1.3.0-nullsafety
   pedantic: ^1.4.0
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/chunked_stream/test/chunk_stream_test.dart
+++ b/chunked_stream/test/chunk_stream_test.dart
@@ -14,6 +14,7 @@
 
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';
+import 'package:typed_data/typed_data.dart';
 
 void main() {
   for (var N = 1; N < 6; N++) {
@@ -42,6 +43,19 @@ void main() {
       expect(chunks.removeLast(), hasLength(lessThanOrEqualTo(N)));
       // Last chunk must be N
       expect(chunks, everyElement(hasLength(N)));
+    });
+
+    test('asChunkedStream (N = $N) can use custom buffers', () async {
+      final s = (() async* {
+        for (var j = 0; j < 97; j++) {
+          yield j;
+        }
+      })();
+
+      final chunks =
+          await asChunkedStream(N, s, newBuffer: () => Uint8Buffer()).toList();
+
+      expect(chunks, everyElement(isA<Uint8Buffer>()));
     });
   }
 }

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';
+import 'package:typed_data/typed_data.dart';
 
 Stream<List<T>> _chunkedStream<T>(List<List<T>> chunks) async* {
   for (final chunk in chunks) {
@@ -363,5 +364,19 @@ void main() {
     expect(await nested.read(3), equals(['2', '3']));
     expect(await nested.read(2), equals([]));
     expect(await s.read(1), equals(['4']));
+  });
+
+  test('custom buffer', () async {
+    final s = ChunkedStreamIterator(
+      _chunkedStream([
+        [1.2],
+        [3.4],
+        [5.6],
+      ]),
+      newBuffer: () => Float32Buffer(),
+    );
+
+    expect(await s.read(1), isA<Float32Buffer>());
+    expect(await s.read(2), isA<Float32Buffer>());
   });
 }

--- a/chunked_stream/test/read_chunked_stream_test.dart
+++ b/chunked_stream/test/read_chunked_stream_test.dart
@@ -14,6 +14,7 @@
 
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';
+import 'package:typed_data/typed_buffers.dart';
 
 void main() {
   test('readChunkedStream', () async {
@@ -23,5 +24,16 @@ void main() {
       yield ['c'];
     })();
     expect(await readChunkedStream(s), equals(['a', 'b', 'c']));
+  });
+
+  test('readChunkedStream with custom buffer', () {
+    final s = (() async* {
+      yield [1, 2, 3];
+      yield [4, 5];
+      yield [6];
+    })();
+
+    expect(readChunkedStream(s, newBuffer: () => Uint8Buffer()),
+        completion(isA<Uint8Buffer>().having((b) => b.length, 'length', 6)));
   });
 }


### PR DESCRIPTION
Adds an optional `newBuffer` argument to methods managing an internal buffer. When reading chunks of byte streams, a buffer implementation backed by typed data can be used to improve memory efficiency.