### PR TITLE
Added readByteStream and prepare 1.4.0-null-safe.0 release

### DIFF
--- a/chunked_stream/CHANGELOG.md
+++ b/chunked_stream/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.4.0-nullsafety.0
+- Added `readByteStream` which uses `BytesBuilder` from `dart:typed_data` under
+  the hood.
+- Added `readBytes` to `ChunkedStreamIterator<int>` for reading byte streams
+  into `Uint8List`.
+- Added `@sealed` annotation to all exported classes.
+
 ## v1.3.0-nullsafety.0
 
 - Migrated to null safety

--- a/chunked_stream/README.md
+++ b/chunked_stream/README.md
@@ -14,13 +14,35 @@ be very inefficient, as each byte would be passed as an individual event.
 Instead bytes arrives in chunks (`List<int>`) and the type of a byte stream
 is `Stream<List<int>>`.
 
-To make it easy to work with the chunk streams, such as `Stream<List<int>>`,
+For easily converting a byte stream `Stream<List<int>>` into a single byte
+buffer `Uint8List` (which implements `List<int>`) this package provides
+`readByteStream(stream, maxSize: 1024*1024)`, which conviniently takes an
+optional `maxSize` parameter to help avoid running out of memory.
+
+**Example**
+```dart
+import 'dart:io';
+import 'dart:convert';
+import 'package:chunked_stream/chunked_stream.dart';
+
+Future<void> main() async {
+  // Open README.md as a byte stream
+  Stream<List<int>> fileStream = File('README.md').openRead();
+
+  // Read all bytes from the stream
+  final Uint8List bytes = await readByteStream(fileStream);
+  
+  // Convert content to string using utf8 codec from dart:convert and print
+  print(utf8.decode(bytes));
+}
+```
+
+To make it easy to process chunked streams, such as `Stream<List<int>>`,
 this package provides `ChunkedStreamIterator` which allows you to specify how
 many elements you want, and buffer unconsumed elements, making it easy to work
 with chunked streams one element at the time.
 
-## Example
-
+**Example**
 ```dart
 final reader = ChunkedStreamIterator(File('my-file.txt').openRead());
 // While the reader has a next byte

--- a/chunked_stream/README.md
+++ b/chunked_stream/README.md
@@ -16,7 +16,7 @@ is `Stream<List<int>>`.
 
 For easily converting a byte stream `Stream<List<int>>` into a single byte
 buffer `Uint8List` (which implements `List<int>`) this package provides
-`readByteStream(stream, maxSize: 1024*1024)`, which conviniently takes an
+`readByteStream(stream, maxSize: 1024*1024)`, which conveniently takes an
 optional `maxSize` parameter to help avoid running out of memory.
 
 **Example**

--- a/chunked_stream/lib/chunked_stream.dart
+++ b/chunked_stream/lib/chunked_stream.dart
@@ -17,8 +17,9 @@
 /// This library provides the following utilities:
 ///  * [ChunkedStreamIterator], for reading a chunked stream by iterating over
 ///  chunks and splitting into substreams.
+///  * [readByteStream], for reading a byte stream into a single [Uint8List].
+///  Often useful for converting [Stream<List<int>>] to [Uint8List].
 ///  * [readChunkedStream], for reading a chunked stream into a single big list.
-///  Often useful for converting [Stream<List<int>>] to [List<int>].
 ///  * [limitChunkedStream], for wrapping a chunked stream as a new stream with
 ///  length limit, useful when accepting input streams from untrusted network.
 ///  * [bufferChunkedStream], for buffering a chunked stream. This can be useful
@@ -28,6 +29,8 @@
 ///  * [asChunkedStream], for wrapping a [Stream<T>] as [Stream<List<T>>],
 ///  useful for batch processing elements from a stream.
 library chunked_stream;
+
+import 'dart:typed_data';
 
 import 'src/chunk_stream.dart';
 import 'src/chunked_stream_buffer.dart';

--- a/chunked_stream/lib/src/read_chunked_stream.dart
+++ b/chunked_stream/lib/src/read_chunked_stream.dart
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import 'dart:async' show Stream, Future;
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart' show sealed;
 
 /// Read all chunks from [input] and return a list consisting of items from all
 /// chunks.
@@ -30,6 +33,9 @@ import 'dart:async' show Stream, Future;
 ///   return contents;
 /// }
 /// ```
+///
+/// If reading a byte stream of type [Stream<List<int>>] consider using
+/// [readByteStream] instead.
 Future<List<T>> readChunkedStream<T>(
   Stream<List<T>> input, {
   int? maxSize,
@@ -47,6 +53,52 @@ Future<List<T>> readChunkedStream<T>(
     }
   }
   return result;
+}
+
+/// Read all bytes from [input] and return a [Uint8List] consisting of all bytes
+/// from [input].
+///
+/// If the maximum number of bytes exceeded [maxSize] this will stop reading and
+/// throw [MaximumSizeExceeded].
+///
+/// **Example**
+/// ```dart
+/// import 'dart:io';
+///
+/// Uint8List readFile(String filePath) async {
+///   Stream<List<int>> fileStream = File(filePath).openRead();
+///   Uint8List contents = await readByteStream(fileStream);
+///   return contents;
+/// }
+/// ```
+///
+/// This method does the same as [readChunkedStream], except it returns a
+/// [Uint8List] which can be faster when working with bytes.
+///
+/// **Remark** The returned [Uint8List] might be a view on a
+/// larger [ByteBuffer]. Do not use [Uint8List.buffer] without taking into
+/// account [Uint8List.lengthInBytes] and [Uint8List.offsetInBytes].
+/// Doing so is never correct, but in many common cases an instance of
+/// [Uint8List] will not be a view on a larger buffer, so such mistakes can go
+/// undetected. Consider using [Uint8List.sublistView], to create subviews if
+/// necessary.
+Future<Uint8List> readByteStream(
+  Stream<List<int>> input, {
+  int? maxSize,
+}) async {
+  ArgumentError.checkNotNull(input, 'input');
+  if (maxSize != null && maxSize < 0) {
+    throw ArgumentError.value(maxSize, 'maxSize must be positive, if given');
+  }
+
+  final result = BytesBuilder();
+  await for (final chunk in input) {
+    result.add(chunk);
+    if (maxSize != null && result.length > maxSize) {
+      throw MaximumSizeExceeded(maxSize);
+    }
+  }
+  return result.takeBytes();
 }
 
 /// Create a _chunked stream_ limited to the first [maxSize] items from [input].
@@ -73,10 +125,13 @@ Stream<List<T>> limitChunkedStream<T>(
 }
 
 /// Exception thrown if [maxSize] was exceeded while reading a _chunked stream_.
+///
+/// This is typically thrown by [readChunkedStream] or [readByteStream].
+@sealed
 class MaximumSizeExceeded implements Exception {
   final int maxSize;
   const MaximumSizeExceeded(this.maxSize);
+
   @override
-  String toString() =>
-      'Input stream exceeded the maxSize: $maxSize passed to readChunkedStream';
+  String toString() => 'Input stream exceeded the maxSize: $maxSize';
 }

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -1,5 +1,5 @@
 name: chunked_stream
-version: 1.3.0-nullsafety.0
+version: 1.4.0-nullsafety.0
 description: |
   Utilities for working with chunked streams, such as byte streams which is
   often given as a stream of byte chunks with type `Stream<List<int>>`.
@@ -9,5 +9,6 @@ issue_tracker: https://github.com/google/dart-neats/labels/pkg:chunked_stream
 dev_dependencies:
   test: ^1.16.0-nullsafety
   pedantic: ^1.4.0
+  meta: ^1.3.0-nullsafety.6
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/chunked_stream/pubspec.yaml
+++ b/chunked_stream/pubspec.yaml
@@ -6,9 +6,10 @@ description: |
 homepage: https://github.com/google/dart-neats/tree/master/chunked_stream
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:chunked_stream
+dependencies:
+  meta: ^1.3.0-nullsafety.6
 dev_dependencies:
   test: ^1.16.0-nullsafety
   pedantic: ^1.4.0
-  meta: ^1.3.0-nullsafety.6
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';

--- a/chunked_stream/test/chunked_stream_iterator_test.dart
+++ b/chunked_stream/test/chunked_stream_iterator_test.dart
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import 'dart:async';
+import 'dart:ffi';
+import 'dart:typed_data';
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';
 
@@ -363,5 +365,17 @@ void main() {
     expect(await nested.read(3), equals(['2', '3']));
     expect(await nested.read(2), equals([]));
     expect(await s.read(1), equals(['4']));
+  });
+
+  test('ByteStreamIterator', () async {
+    final s = ChunkedStreamIterator(_chunkedStream([
+      [1, 2, 3],
+      [4],
+    ]));
+    expect(await s.readBytes(1), equals([1]));
+    expect(await s.readBytes(1), isA<Uint8List>());
+    expect(await s.readBytes(1), equals([3]));
+    expect(await s.readBytes(1), equals([4]));
+    expect(await s.readBytes(1), equals([]));
   });
 }

--- a/chunked_stream/test/read_chunked_stream_test.dart
+++ b/chunked_stream/test/read_chunked_stream_test.dart
@@ -33,15 +33,8 @@ void main() {
       yield Uint8List.fromList([3]);
       yield [4];
     })();
-    expect(await readByteStream(s), equals([1, 2, 3, 4]));
-  });
-
-  test('readByteStream returns Uint8List', () async {
-    final s = (() async* {
-      yield Uint8List.fromList([1, 2]);
-      yield Uint8List.fromList([3]);
-      yield Uint8List.fromList([4]);
-    })();
-    expect(await readByteStream(s), isA<Uint8List>());
+    final result = await readByteStream(s);
+    expect(result, equals([1, 2, 3, 4]));
+    expect(result, isA<Uint8List>());
   });
 }

--- a/chunked_stream/test/read_chunked_stream_test.dart
+++ b/chunked_stream/test/read_chunked_stream_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:chunked_stream/chunked_stream.dart';
 
@@ -23,5 +25,23 @@ void main() {
       yield ['c'];
     })();
     expect(await readChunkedStream(s), equals(['a', 'b', 'c']));
+  });
+
+  test('readByteStream', () async {
+    final s = (() async* {
+      yield [1, 2];
+      yield Uint8List.fromList([3]);
+      yield [4];
+    })();
+    expect(await readByteStream(s), equals([1, 2, 3, 4]));
+  });
+
+  test('readByteStream returns Uint8List', () async {
+    final s = (() async* {
+      yield Uint8List.fromList([1, 2]);
+      yield Uint8List.fromList([3]);
+      yield Uint8List.fromList([4]);
+    })();
+    expect(await readByteStream(s), isA<Uint8List>());
   });
 }


### PR DESCRIPTION
@simolus3

Given that we use `.sublist` in `ChunkedStreamIterator` we don't really need to do much to byte stream specially.
Well, at-least not if those byte streams contains `Uint8List` which many of the streams from `dart:io` do, even if the type is `Stream<List<int>>`. Besides, even if there is a `List<int>` instance in there, most of the chunks are probably not going to be split, as they just pass right through.

The only place where it's a bit annoying is `ChunkedStreamIterator.read`, but I figured we could just introduce an extension method `ChunkedStreamIterator.readBytes` which returns `Uint8List`. I doubt there are many special cases where you want to use a specific kind of List type, it pretty much only makes sense for byte streams (I hope).

Also added `readByteStream` to complement `readChunkedStream`.