### PR TITLE
Migrate http_methods to Dart null safety

### DIFF
--- a/http_methods/pubspec.yaml
+++ b/http_methods/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_methods
-version: 1.0.0
+version: 2.0.0-nullsafety.0
 description: |
   List of all HTTP methods registered with IANA as list of strings, and metadata
   such as whether a method idempotent.
@@ -7,7 +7,7 @@ homepage: https://github.com/google/dart-neats/tree/master/http_methods
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:http_methods
 dev_dependencies:
-  test: ^1.5.1
-  pedantic: ^1.4.0
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
This is a requirement for shelf_router migration, which will come in a separate PR