### PR TITLE
shelf_router_generator: Support null-safe dependencies

### DIFF
--- a/shelf_router_generator/CHANGELOG.md
+++ b/shelf_router_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.0.0-dev
+
+ * Support update-to-date dependencies.
+ * Generate null-safe code.
+
 ## v0.7.2+4
 
  * Relax dependency constraint on `analyzer`.

--- a/shelf_router_generator/example/main.dart
+++ b/shelf_router_generator/example/main.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart=2.12
+
 import 'dart:async' show Future;
 import 'package:shelf_router/shelf_router.dart';
 import 'package:shelf/shelf.dart';
@@ -55,7 +57,7 @@ class Service {
 
   // The generated function _$ServiceRouter can be used to get a [Handler]
   // for this object. This can be used with [shelf_io.serve].
-  Handler get handler => _$ServiceRouter(this).handler;
+  Handler get handler => _$ServiceRouter(this);
 }
 
 class Api {

--- a/shelf_router_generator/example/main.g.dart
+++ b/shelf_router_generator/example/main.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'main.dart';
 

--- a/shelf_router_generator/lib/src/shelf_router_generator.dart
+++ b/shelf_router_generator/lib/src/shelf_router_generator.dart
@@ -44,10 +44,10 @@ class _Handler {
 /// Find members of a class annotated with [shelf_router.Route].
 List<ExecutableElement> getAnnotatedElementsOrderBySourceOffset(
     ClassElement cls) {
-  return <ExecutableElement>[]
-    ..addAll(cls.methods.where(_routeType.hasAnnotationOfExact))
-    ..addAll(cls.accessors.where(_routeType.hasAnnotationOfExact))
-    ..sort((a, b) => (a.nameOffset ?? -1).compareTo(b.nameOffset ?? -1));
+  return <ExecutableElement>[
+    ...cls.methods.where(_routeType.hasAnnotationOfExact),
+    ...cls.accessors.where(_routeType.hasAnnotationOfExact)
+  ]..sort((a, b) => (a.nameOffset ?? -1).compareTo(b.nameOffset ?? -1));
 }
 
 /// Generate a `_$<className>Router(<className> service)` method that returns a

--- a/shelf_router_generator/pubspec.yaml
+++ b/shelf_router_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router_generator
-version: 0.7.2+4
+version: 1.0.0-dev
 description: |
   A package:build compatible builder for generating request routers for the
   shelf web-framework based on source annotations.
@@ -7,20 +7,20 @@ homepage: https://github.com/google/dart-neats/tree/master/shelf_router_generato
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:shelf_router_generator
 dependencies:
-  build: ^1.0.0
-  build_config: '>= 0.3.1 <= 0.5.0'
+  build: ^2.0.0
+  build_config: ^0.4.0
   source_gen: ^0.9.1
-  analyzer:  '>=0.35.0 < 0.42.0'
-  shelf_router: ^0.7.0
+  analyzer: ^1.2.0
+  shelf_router: ^1.0.0
   code_builder: ^3.2.0
-  shelf: ^0.7.3
+  shelf: ^1.1.0
   meta: ^1.1.7
   http_methods: ^1.0.0
 dev_dependencies:
   test: ^1.5.3
-  http: ^0.12.0+1
-  build_verify: ^1.1.1
+  http: ^0.13.0
+  build_verify: ^2.0.0
   build_runner: ^1.4.0
   pedantic: ^1.4.0
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.11.99 <3.0.0'

--- a/shelf_router_generator/test/server/api.dart
+++ b/shelf_router_generator/test/server/api.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart=2.12
+
 import 'dart:async' show Future;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';

--- a/shelf_router_generator/test/server/api.g.dart
+++ b/shelf_router_generator/test/server/api.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'api.dart';
 

--- a/shelf_router_generator/test/server/server.dart
+++ b/shelf_router_generator/test/server/server.dart
@@ -12,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart=2.12
+
 import 'dart:async' show Future;
 import 'dart:io' show HttpServer;
+
 import 'package:shelf/shelf_io.dart' as shelf_io;
+
 import 'service.dart';
 
 class Server {
   final _service = Service();
-  HttpServer _server;
+  late HttpServer _server;
 
   Future<void> start() async {
-    _server = await shelf_io.serve(_service.router.handler, 'localhost', 0);
+    _server = await shelf_io.serve(_service.router, 'localhost', 0);
   }
 
   Future<void> stop() {

--- a/shelf_router_generator/test/server/service.dart
+++ b/shelf_router_generator/test/server/service.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart=2.12
+
 import 'dart:async' show Future, FutureOr;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';

--- a/shelf_router_generator/test/server/service.g.dart
+++ b/shelf_router_generator/test/server/service.g.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// @dart=2.12
 
 part of 'service.dart';
 

--- a/shelf_router_generator/test/server/unrelatedannotation.dart
+++ b/shelf_router_generator/test/server/unrelatedannotation.dart
@@ -1,3 +1,5 @@
+// @dart=2.12
+
 /// Annotation for an API end-point.
 class EndPoint {
   /// HTTP verb for requests routed to the annotated method.

--- a/shelf_router_generator/test/server_test.dart
+++ b/shelf_router_generator/test/server_test.dart
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:test/test.dart';
-import 'package:meta/meta.dart';
+// @dart=2.12
+
 import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
 import 'server/server.dart';
 
 void main() {
@@ -23,11 +25,11 @@ void main() {
   tearDownAll(() => server.stop());
 
   void testGet({
-    @required String path,
-    @required String result,
+    required String path,
+    required String result,
   }) =>
       test('GET $path', () async {
-        final result = await http.read(server.uri.resolve(path));
+        final result = await http.get(server.uri.resolve(path));
         expect(result, equals(result));
       });
 


### PR DESCRIPTION
Just need to wait on pkg:source_gen to get published to make this fully null-safe
