### PR TITLE
Updated dependencies

### DIFF
--- a/yaml_edit/pubspec.yaml
+++ b/yaml_edit/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/google/dart-neats/tree/master/yaml_edit
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:yaml_edit
 dependencies:
-  collection: ^1.14.11
-  meta: ^1.1.8
-  source_span: ^1.7.0
-  yaml: ^2.2.1
+  collection: ^1.15.0
+  meta: ^1.3.0
+  source_span: ^1.8.1
+  yaml: ^3.1.0
 dev_dependencies:
-  path: ^1.6.2
-  pedantic: ^1.9.0
-  test: ^1.14.4
+  path: ^1.8.0
+  pedantic: ^1.11.0
+  test: ^1.17.2
 environment:
   sdk: ">=2.4.0 <3.0.0"


### PR DESCRIPTION
Packages that are dependent on this are not being able to migrate to null-safety due to the `yaml` dep being out of date.