### PR TITLE
[DRAFT] Remove constraint to mount routes without trailing slash (fixes #67)

### DIFF
--- a/shelf_router/lib/src/router.dart
+++ b/shelf_router/lib/src/router.dart
@@ -120,7 +120,7 @@ class Router {
   ///
   /// In this case prefix may not contain any parameters, nor
   void mount(String prefix, Handler handler) {
-    if (!prefix.startsWith('/') || !prefix.endsWith('/')) {
+    if (!prefix.startsWith('/')) {
       throw ArgumentError.value(
           prefix, 'prefix', 'must start and end with a slash');
     }

--- a/shelf_router/lib/src/router.dart
+++ b/shelf_router/lib/src/router.dart
@@ -121,8 +121,7 @@ class Router {
   /// In this case prefix may not contain any parameters, nor
   void mount(String prefix, Handler handler) {
     if (!prefix.startsWith('/')) {
-      throw ArgumentError.value(
-          prefix, 'prefix', 'must start and end with a slash');
+      throw ArgumentError.value(prefix, 'prefix', 'must start with a slash');
     }
 
     // first slash is always in request.handlerPath

--- a/shelf_router/test/router_test.dart
+++ b/shelf_router/test/router_test.dart
@@ -103,12 +103,18 @@ void main() {
       return Response.ok('Hello $user');
     });
 
+    var api2 = Router();
+    api2.get('/', (Request request) {
+      return Response.ok('api2');
+    });
+
     var app = Router();
     app.get('/hello', (Request request) {
       return Response.ok('hello-world');
     });
 
-    app.mount('/api/', api);
+    app.mount('/api', api);
+    app.mount('/api2', api2);
 
     app.all('/<_|[^]*>', (Request request) {
       return Response.notFound('catch-all-handler');
@@ -118,6 +124,8 @@ void main() {
 
     expect(await get('/hello'), 'hello-world');
     expect(await get('/api/user/jonasfj/info'), 'Hello jonasfj');
+    expect(await get('/api2'), 'api2');
+    expect(get('/api2/'), throwsA(anything));
     expect(get('/api/user/jonasfj/info-wrong'), throwsA(anything));
   });
 
@@ -138,7 +146,7 @@ void main() {
 
     var app = Router();
     app.mount(
-      '/api/',
+      '/api',
       Pipeline().addMiddleware(middleware).addHandler(api),
     );
 


### PR DESCRIPTION
Hi. 

This MR is still a draft, because the added testcase is still failing. I am not sure if this a new bug or has something to do with the code change. Till now I was not able to figure out the root case for it.

The failing testcase tries to mount a router (has prefix '/') on another handler with the prefix '/api2'. There is also another handler mounted at '/api' which get called instead of '/api2'. If you change the order it works. 

I think this has something to do with the pattern matching or the creation of the regex pattern at the RouteEntry class. For '/api2' the params 'path: 2' will be generated which can't be correct.