### PR TITLE
Introduce `routeNotFound` sentinel for shelf_router 1.1.0

### DIFF
--- a/shelf_router/CHANGELOG.md
+++ b/shelf_router/CHANGELOG.md
@@ -1,3 +1,25 @@
+## v1.1.0
+ * `params` is deprecated in favor of `Request.params` adding using an extension
+   on `Request`.
+ * The default `notFoundHandler` now returns a sentinel `routeNotFound` response
+   object which causes 404 with the message 'Route not found'.
+ * __Minor breaking__: Handlers and sub-routers that return the sentinel
+   `routeNotFound` response object will be ignored and pattern matching will
+   continue on additional routes/handlers.
+
+Changing the router to continue pattern matching additional routes if a matched
+_handler_ or _nested router_ returns the sentinel `routeNotFound` response
+object is technically a _breaking change_. However, it only affects scenarios
+where the request matches a _mounted sub-router_, but does not match any route
+on this sub-router. In this case, `shelf_router` version `1.0.0` would
+immediately respond 404, without attempting to match further routes. With this
+release, the behavior changes to matching additional routes until one returns
+a custom 404 response object, or all routes have been matched.
+
+This behavior is more in line with how `shelf_router` version `0.7.x` worked,
+and since many affected users consider the behavior from `1.0.0` a defect,
+we decided to remedy the situation.
+
 ## v1.0.0
 
  * Migrate package to null-safety

--- a/shelf_router/pubspec.yaml
+++ b/shelf_router/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router
-version: 1.0.0
+version: 1.1.0
 description: |
   A convinent request router for the shelf web-framework, with support for
   URL-parameters, nested routers and routers generated from source annotations.

--- a/shelf_router/test/router_test.dart
+++ b/shelf_router/test/router_test.dart
@@ -74,8 +74,8 @@ void main() {
     var app = Router();
 
     app.get(r'/user/<user>/groups/<group|\d+>', (Request request) {
-      final user = params(request, 'user');
-      final group = params(request, 'group');
+      final user = request.params['user'];
+      final group = request.params['group'];
       return Response.ok('$user / $group');
     });
 
@@ -111,14 +111,14 @@ void main() {
     app.mount('/api/', api);
 
     app.all('/<_|[^]*>', (Request request) {
-      return Response.notFound('catch-all-handler');
+      return Response.ok('catch-all-handler');
     });
 
     server.mount(app);
 
     expect(await get('/hello'), 'hello-world');
     expect(await get('/api/user/jonasfj/info'), 'Hello jonasfj');
-    expect(get('/api/user/jonasfj/info-wrong'), throwsA(anything));
+    expect(await get('/api/user/jonasfj/info-wrong'), 'catch-all-handler');
   });
 
   test('mount(Handler) with middleware', () async {


### PR DESCRIPTION
Fixing https://github.com/google/dart-neats/issues/136