### PR TITLE
Fix Router.routeNotFound to enable multiple read() calls on it.

### DIFF
--- a/shelf_router/CHANGELOG.md
+++ b/shelf_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1
+
+ * Fix `Router.routeNotFound` to enable multiple `read()` calls on it.
+
 ## v1.1.0
  * `params` is deprecated in favor of `Request.params` adding using an extension
    on `Request`.

--- a/shelf_router/lib/src/router.dart
+++ b/shelf_router/lib/src/router.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'dart:collection' show UnmodifiableMapView;
+import 'dart:convert';
 
 import 'package:http_methods/http_methods.dart';
 import 'package:meta/meta.dart' show sealed;
@@ -267,5 +268,30 @@ class Router {
   ///   return Response.notFound('nothing found');
   /// });
   /// ```
-  static final Response routeNotFound = Response.notFound('Route not found');
+  static final Response routeNotFound = _RouteNotFoundResponse();
+}
+
+/// Extends [Response] to allow it to be used multiple times in the
+/// actual content being served.
+class _RouteNotFoundResponse extends Response {
+  static const _message = 'Route not found';
+  static final _messageBytes = utf8.encode(_message);
+
+  _RouteNotFoundResponse() : super.notFound(_message);
+
+  @override
+  Stream<List<int>> read() => Stream<List<int>>.value(_messageBytes);
+
+  @override
+  Response change({
+    Map<String, /* String | List<String> */ Object?>? headers,
+    Map<String, Object?>? context,
+    body,
+  }) {
+    return super.change(
+      headers: headers,
+      context: context,
+      body: body ?? _message,
+    );
+  }
 }

--- a/shelf_router/pubspec.yaml
+++ b/shelf_router/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_router
-version: 1.1.0
+version: 1.1.1
 description: |
   A convinent request router for the shelf web-framework, with support for
   URL-parameters, nested routers and routers generated from source annotations.

--- a/shelf_router/test/router_test.dart
+++ b/shelf_router/test/router_test.dart
@@ -165,4 +165,11 @@ void main() {
 
     expect(get('/hi'), completion('Not found, but ok'));
   });
+
+  test('can call Router.routeNotFound.read multiple times', () async {
+    final b1 = await Router.routeNotFound.readAsString();
+    expect(b1, 'Route not found');
+    final b2 = await Router.routeNotFound.readAsString();
+    expect(b2, b1);
+  });
 }


### PR DESCRIPTION
- Fixes #144, a slightly more compact version of #145.
- Additional test.