### PR TITLE
Fix SDK constraints 2.12.0-0 to 2.12.0

### DIFF
--- a/http_methods/pubspec.yaml
+++ b/http_methods/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/google/dart-neats/tree/master/http_methods
 repository: https://github.com/google/dart-neats.git
 issue_tracker: https://github.com/google/dart-neats/labels/pkg:http_methods
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   test: ^1.16.0
   pedantic: ^1.10.0

--- a/neat_periodic_task/pubspec.yaml
+++ b/neat_periodic_task/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   build_verify: ^1.1.1
   json_serializable: ^4.0.2
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 

--- a/pem/pubspec.yaml
+++ b/pem/pubspec.yaml
@@ -13,5 +13,5 @@ dev_dependencies:
   test: ^1.16.5
   pedantic: ^1.10.0
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 

--- a/retry/pubspec.yaml
+++ b/retry/pubspec.yaml
@@ -10,4 +10,4 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.13
   pedantic: ^1.4.0
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"

--- a/sanitize_html/pubspec.yaml
+++ b/sanitize_html/pubspec.yaml
@@ -14,4 +14,4 @@ dev_dependencies:
   pedantic: ^1.4.0
   markdown: ^4.0.0
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'

--- a/shelf_router/pubspec.yaml
+++ b/shelf_router/pubspec.yaml
@@ -15,4 +15,4 @@ dev_dependencies:
   pedantic: ^1.10.0
   http: ^0.13.0
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'

--- a/slugid/pubspec.yaml
+++ b/slugid/pubspec.yaml
@@ -13,4 +13,4 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.12
   pedantic: ^1.10.0-nullsafety.3
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Just to reduce warnings when publishing in the future.