### PR TITLE
Send QUIT command when closing the connection without force: true.

### DIFF
--- a/neat_cache/CHANGELOG.md
+++ b/neat_cache/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.2
+ * Send `QUIT` command when closing the connection without `force: true`.
+
 ## v2.0.1
  * Fixed issue when adding multiple commands without waiting for them to complete first.
 

--- a/neat_cache/lib/src/providers/resp.dart
+++ b/neat_cache/lib/src/providers/resp.dart
@@ -203,7 +203,7 @@ class RespClient {
   Future<void> close({bool force = false}) async {
     _closing = true;
 
-    if (!_closing) {
+    if (!force) {
       // Always send QUIT message to be nice
       try {
         final quit = command(['QUIT']);

--- a/neat_cache/pubspec.yaml
+++ b/neat_cache/pubspec.yaml
@@ -1,5 +1,5 @@
 name: neat_cache
-version: 2.0.1
+version: 2.0.2-dev
 description: |
   A neat cache abstraction for wrapping in-memory or redis caches.
 homepage: https://github.com/google/dart-neats/tree/master/neat_cache


### PR DESCRIPTION
As we set `_closing = true` in the line above the if condition, I think the expression should depend on the `force` parameter.