### PR TITLE
Extend sanitize

### DIFF
--- a/sanitize_html/lib/sanitize_html.dart
+++ b/sanitize_html/lib/sanitize_html.dart
@@ -14,7 +14,10 @@
 
 library sanitize_html;
 
-import 'src/sane_html_validator.dart' show SaneHtmlValidator;
+import 'src/sane_html_validator.dart'
+    show SaneHtmlValidator, AllowTagCB, AllowAttributeCB;
+export 'src/sane_html_validator.dart'
+    show AllowTagCB, AllowAttributeCB, AllowAttributeResponse;
 
 /// Sanitize [htmlString] to prevent XSS exploits and limit interference with
 /// other markup on the page.
@@ -76,10 +79,14 @@ String sanitizeHtml(
   bool Function(String)? allowElementId,
   bool Function(String)? allowClassName,
   Iterable<String>? Function(String)? addLinkRel,
+  AllowTagCB? allowTag,
+  AllowAttributeCB? allowAttribute,
 }) {
   return SaneHtmlValidator(
     allowElementId: allowElementId,
     allowClassName: allowClassName,
     addLinkRel: addLinkRel,
+    allowTag: allowTag,
+    allowAttribute: allowAttribute,
   ).sanitize(htmlString);
 }

--- a/sanitize_html/lib/src/sane_html_validator.dart
+++ b/sanitize_html/lib/src/sane_html_validator.dart
@@ -231,9 +231,11 @@ class AllowAttributeResponse {
   /// Factory function for unchaged action
   factory AllowAttributeResponse.unchanged() =>
       AllowAttributeResponse(ResponseAction.unchanged);
+
   /// Factory function for edit action
   factory AllowAttributeResponse.edit(String value) =>
       AllowAttributeResponse(ResponseAction.edit, value);
+
   /// Factory function for remove action
   factory AllowAttributeResponse.remove() =>
       AllowAttributeResponse(ResponseAction.remove);
@@ -251,8 +253,10 @@ class SaneHtmlValidator {
   final bool Function(String)? allowElementId;
   final bool Function(String)? allowClassName;
   final Iterable<String>? Function(String)? addLinkRel;
+
   /// Callback function to check for allowed tags
   final AllowTagCB? allowTag;
+
   /// Callback function to check for allowed attributes
   final AllowAttributeCB? allowAttribute;
 

--- a/sanitize_html/test/sanitize_html_test.dart
+++ b/sanitize_html/test/sanitize_html_test.dart
@@ -13,7 +13,29 @@
 // limitations under the License.
 
 import 'package:test/test.dart';
-import 'package:sanitize_html/sanitize_html.dart' show sanitizeHtml;
+import 'package:sanitize_html/sanitize_html.dart'
+    show sanitizeHtml, AllowTagCB, AllowAttributeCB, AllowAttributeResponse;
+
+final otherTagList = <String>{'CSTM', 'A'};
+bool customTagList(String t) => otherTagList.contains(t);
+AllowAttributeResponse customAttrList(
+    String tag, String attrName, String attrValue) {
+  if (attrName.toUpperCase() == 'CLASS') {
+    final k = attrValue.split(' ');
+    k.removeWhere((v) => !v.endsWith('allowed'));
+    return AllowAttributeResponse.edit(k.join(' '));
+  }
+  if (tag.toUpperCase() == 'DIV') {
+    if (attrName.toUpperCase() == 'ALT') {
+      return AllowAttributeResponse.unchanged();
+    }
+    return AllowAttributeResponse.remove();
+  }
+  if (attrName.toUpperCase() == 'DATA-KEY') {
+    return AllowAttributeResponse.edit('new-value');
+  }
+  return AllowAttributeResponse.remove();
+}
 
 void main() {
   // Calls sanitizeHtml with two different configurations.
@@ -21,10 +43,15 @@ void main() {
   // and `addLinkRel` overrides are passed to the sanitizeHtml call of `template`.
   // (This is the default behavior for the [testContains]/[testNotContains] methods.)
   //  * When `withOptionalConfiguration` is false: only `template` is passed.
-  String doSanitizeHtml(String template,
-      {required bool withOptionalConfiguration}) {
+  String doSanitizeHtml(
+    String template, {
+    required bool withOptionalConfiguration,
+    AllowTagCB? withCustomTagList,
+    AllowAttributeCB? withCustomAttrList,
+  }) {
     if (!withOptionalConfiguration) {
-      return sanitizeHtml(template);
+      return sanitizeHtml(template,
+          allowTag: withCustomTagList, allowAttribute: withCustomAttrList,);
     }
 
     return sanitizeHtml(
@@ -32,26 +59,42 @@ void main() {
       allowElementId: (id) => id == 'only-allowed-id',
       allowClassName: (className) => className == 'only-allowed-class',
       addLinkRel: (href) => href == 'bad-link' ? ['ugc', 'nofollow'] : null,
+      allowTag: withCustomTagList,
+      allowAttribute: withCustomAttrList,
     );
   }
 
-  void testContains(String template, String needle,
-      {bool withOptionalConfiguration = true}) {
+  void testContains(
+    String template,
+    String needle, {
+    bool withOptionalConfiguration = true,
+    AllowTagCB? withCustomTagList,
+    AllowAttributeCB? withCustomAttrList,
+  }) {
     test('"$template" does contain "$needle"', () {
       final sanitizedHtml = doSanitizeHtml(
         template,
         withOptionalConfiguration: withOptionalConfiguration,
+        withCustomTagList: withCustomTagList,
+        withCustomAttrList: withCustomAttrList,
       );
       expect(sanitizedHtml, contains(needle));
     });
   }
 
-  void testNotContains(String template, String needle,
-      {bool withOptionalConfiguration = true}) {
+  void testNotContains(
+    String template,
+    String needle, {
+    bool withOptionalConfiguration = true,
+    AllowTagCB? withCustomTagList,
+    AllowAttributeCB? withCustomAttrList,
+  }) {
     test('"$template" does not contain "$needle"', () {
       final sanitizedHtml = doSanitizeHtml(
         template,
         withOptionalConfiguration: withOptionalConfiguration,
+        withCustomTagList: withCustomTagList,
+        withCustomAttrList: withCustomAttrList,
       );
       expect(sanitizedHtml, isNot(contains(needle)));
     });
@@ -156,5 +199,54 @@ void main() {
         withOptionalConfiguration: false);
     testNotContains('<span class="any-class">hello</span>', 'class=',
         withOptionalConfiguration: false);
+  });
+
+  group('Custom Tag List', () {
+    testContains('<cstm>hello', '<cstm>hello',
+        withCustomTagList: customTagList);
+    testNotContains('<div>hello', 'hello', withCustomTagList: customTagList);
+
+    // custom tags with support for attributes
+    testContains('<cstm id="only-allowed-id">hello</cstm>', 'id',
+        withCustomTagList: customTagList);
+    testContains('<cstm id="only-allowed-id">hello</cstm>', 'only-allowed-id',
+        withCustomTagList: customTagList);
+    testNotContains('<cstm id="disallowed-id">hello</cstm>', 'id',
+        withCustomTagList: customTagList);
+    testNotContains('<cstm id="disallowed-id">hello</cstm>', 'only-allowed-id',
+        withCustomTagList: customTagList);
+    // default rules for A attribute do not works when use customTagList
+    testNotContains('<a href="bad-link">hello', 'rel="ugc nofollow"',
+        withCustomTagList: customTagList);
+
+    testContains('<a href="any-href">hey', 'href=',
+        withOptionalConfiguration: false, withCustomTagList: customTagList);
+    testNotContains('<a href="any-href">hey', 'rel=',
+        withOptionalConfiguration: false, withCustomTagList: customTagList);
+    testNotContains('<cstm id="any-id">hello</cstm>', 'id=',
+        withOptionalConfiguration: false, withCustomTagList: customTagList);
+    testNotContains('<cstm class="any-class">hello</cstm>', 'class=',
+        withOptionalConfiguration: false, withCustomTagList: customTagList);
+
+    // custom tag list handle default allowed attributes if AllowAttributes is missing
+    testContains('<cstm alt="bar">hello', 'alt',
+        withCustomTagList: customTagList);
+  });
+
+  group('Custom Attribute List', () {
+    testNotContains('<span alt="foo">hello', 'alt',
+        withCustomAttrList: customAttrList);
+    testContains('<div alt="foo">hello', 'alt',
+        withCustomAttrList: customAttrList);
+    testNotContains('<div bar="foo">hello', 'bar',
+        withCustomAttrList: customAttrList);
+    testNotContains('<span class="foo-allowed other-attr">hello', 'other-attr',
+        withCustomAttrList: customAttrList);
+    testContains('<span class="foo-allowed other-attr">hello', 'foo-allowed',
+        withCustomAttrList: customAttrList);
+    testContains('<span data-key="value-allowed">hello', 'new-value',
+        withCustomAttrList: customAttrList);
+    testNotContains('<span data-key="value-allowed">hello', 'value-allowed',
+        withCustomAttrList: customAttrList);
   });
 }

--- a/sanitize_html/test/sanitize_html_test.dart
+++ b/sanitize_html/test/sanitize_html_test.dart
@@ -50,8 +50,11 @@ void main() {
     AllowAttributeCB? withCustomAttrList,
   }) {
     if (!withOptionalConfiguration) {
-      return sanitizeHtml(template,
-          allowTag: withCustomTagList, allowAttribute: withCustomAttrList,);
+      return sanitizeHtml(
+        template,
+        allowTag: withCustomTagList,
+        allowAttribute: withCustomAttrList,
+      );
     }
 
     return sanitizeHtml(


### PR DESCRIPTION
This PR extends `sanitize_html` to allow custom tags and attributes.
- Two new callbacks handle the checks
- The internal functions were normalized using the same parameters as the callbacks.
- Test added to check for the new functionality
- There are no changes to how the library worked before and do not require code changes.

An upcoming PR will handle the `remove_contents` option as observed on https://github.com/google/dart-neats/issues/101