### PR TITLE
api_analysis_exploration: improve summary logic for getters/setters

### DIFF
--- a/api_analysis/lib/r2/analyze.dart
+++ b/api_analysis/lib/r2/analyze.dart
@@ -239,8 +239,8 @@ extension on PackageShape {
                 .where((dOther) => d.nameAsString == dOther.nameAsString);
             shape.define(VariableShape(
               name: d.nameAsString,
-              hasGetter: accessors.any((d) => d.isGetter),
-              hasSetter: accessors.any((d) => d.isSetter),
+              hasGetter: accessors.any((a) => a.isGetter),
+              hasSetter: accessors.any((a) => a.isSetter),
             ));
           } else {
             shape.defineFunction(d);

--- a/api_analysis/lib/r2/analyze.dart
+++ b/api_analysis/lib/r2/analyze.dart
@@ -229,16 +229,16 @@ extension on PackageShape {
       switch (d) {
         case FunctionDeclaration d:
           if (d.isGetter || d.isSetter) {
-            if (shape.definedShapes[name] == null) {
-              return; // we've seen the other getter or setter already
+            if (shape.definedShapes.containsKey(d.nameAsString)) {
+              continue; // we've seen the other getter or setter already
               // TODO: Check that the other thing we saw was a getter/setter!
             }
             final accessors = library.units
                 .expand((u) => u.unit.declarations)
                 .whereType<FunctionDeclaration>()
-                .where((d) => d.name.value() == name);
+                .where((dOther) => d.nameAsString == dOther.nameAsString);
             shape.define(VariableShape(
-              name: name,
+              name: d.nameAsString,
               hasGetter: accessors.any((d) => d.isGetter),
               hasSetter: accessors.any((d) => d.isSetter),
             ));


### PR DESCRIPTION
I think this is probably closer to the intended logic:
- if `definedShapes` _contains_ a key with the name of this symbol, then we should _continue_ to the next symbol
- this is an `extension on PackageShape` so `name` refers to the name of this `PackageShape`. we probably want to use `d.nameAsString` instead.
- for me, shadowing makes the code a little less clear to read. in this case, it prevents us from checking what other accessors share the name of the symbol `d` in line 239