### PR TITLE
api_analysis_exploration: account for the case that the `Token` associated with a named parameter is a `StringToken`

### DIFF
--- a/api_analysis/example/lib/foo.dart
+++ b/api_analysis/example/lib/foo.dart
@@ -20,7 +20,7 @@ export 'src/impl.dart'
     hide setterForHello
     show setterForHello;
 
-void sayHello() {
+void sayHello({required String a, String? b}) {
   print(finalHelloMessage);
   _privateMethod();
 }

--- a/api_analysis/lib/r2/analyze.dart
+++ b/api_analysis/lib/r2/analyze.dart
@@ -308,7 +308,7 @@ extension on LibraryShape {
       namedParameters: parameters
           .where((p) => p.isNamed)
           .map((p) => NamedParameterShape(
-              name: p.name!.stringValue!, isRequired: p.isRequired))
+              name: p.name!.value() as String, isRequired: p.isRequired))
           .toList(),
       positionalParameters: parameters
           .where((p) => p.isPositional)


### PR DESCRIPTION
also add example demonstrating the fix
named parameters always have a name (**I hope I got this right!**)