### PR TITLE
api_analysis_exploration: add r3 experiment

### DIFF
--- a/api_analysis/lib/common.dart
+++ b/api_analysis/lib/common.dart
@@ -1,0 +1,36 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+extension LanguageVersionCompatibilityExt on Pubspec {
+  Version get languageVersion {
+    final sdk = (environment ?? {})['sdk'];
+    if (sdk is VersionRange) {
+      final min = sdk.min ?? Version(0, 0, 0);
+      return Version(min.major, min.minor, 0);
+    }
+    // Note: Techincally there are other options
+    return Version(0, 0, 0);
+  }
+
+  bool get dart3Compatible => languageVersion >= Version(2, 12, 0);
+}
+
+extension PackageSchemeExt on Uri {
+  /// True, if this [Uri] points to a resource in [package].
+  bool isInPackage(String package) =>
+      isScheme('package') && pathSegments.firstOrNull == package;
+}
+
+/// Thrown when shape analysis fails.
+///
+/// This typically happens because the Dart code being analyzed is invalid, or
+/// because the analysis is unable to handle the code in question.
+class ShapeAnalysisException implements Exception {
+  final String message;
+  ShapeAnalysisException._(this.message);
+
+  @override
+  String toString() => message;
+}
+
+Never fail(String message) => throw ShapeAnalysisException._(message);

--- a/api_analysis/lib/common.dart
+++ b/api_analysis/lib/common.dart
@@ -19,6 +19,14 @@ extension PackageSchemeExt on Uri {
   /// True, if this [Uri] points to a resource in [package].
   bool isInPackage(String package) =>
       isScheme('package') && pathSegments.firstOrNull == package;
+
+  bool get isInPrivateLibrary {
+    if (pathSegments.length >= 2 && pathSegments[1] == 'src') {
+      assert(pathSegments.length >= 3);
+      return true;
+    }
+    return false;
+  }
 }
 
 /// Thrown when shape analysis fails.

--- a/api_analysis/lib/r3/analyze.dart
+++ b/api_analysis/lib/r3/analyze.dart
@@ -379,7 +379,7 @@ extension on LibraryShape {
     for (final v in d.variables.variables) {
       final name = v.name.value();
       if (name is! String) {
-        throw fail('Unnamed variable $v');
+        fail('Unnamed variable $v');
       }
       define(VariableShape(
         name: name,

--- a/api_analysis/lib/r3/analyze.dart
+++ b/api_analysis/lib/r3/analyze.dart
@@ -1,0 +1,401 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Extraction of a PackageShape using only AST analysis.
+library;
+
+import 'dart:io' show Directory;
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'shapes.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.length != 1) {
+    print('Usage: analyze.dart <target>');
+    return;
+  }
+
+  final packagePath = Directory.current.uri.resolve(args.first);
+  await analyzePackage(packagePath.toFilePath());
+}
+
+/// Thrown when shape analysis fails.
+///
+/// This typically happens because the Dart code being analyzed is invalid, or
+/// because the analysis is unable to handle the code in question.
+class ShapeAnalysisException implements Exception {
+  final String message;
+  ShapeAnalysisException._(this.message);
+
+  @override
+  String toString() => message;
+}
+
+Never _fail(String message) => throw ShapeAnalysisException._(message);
+
+Future<PackageShape> analyzePackage(String packagePath) async {
+  final collection = AnalysisContextCollection(includedPaths: [packagePath]);
+  final context = collection.contextFor(packagePath);
+  final session = context.currentSession;
+
+  final pubspecFile =
+      session.resourceProvider.getFile('$packagePath/pubspec.yaml');
+  final pubspec = Pubspec.parse(
+    pubspecFile.readAsStringSync(),
+    lenient: true,
+    sourceUrl: pubspecFile.toUri(),
+  );
+
+  final package = PackageShape(
+    name: pubspec.name,
+    version: pubspec.version ?? Version(0, 0, 0),
+  );
+
+  // Add all libraries to the PackageShape
+  for (final f in context.contextRoot.analyzedFiles()) {
+    final u = session.uriConverter.pathToUri(f);
+    if (u == null ||
+        !u.isInPackage(package.name) ||
+        !u.path.endsWith('.dart')) {
+      continue;
+    }
+    final library = session.getParsedLibrary(f);
+    if (library is! ParsedLibraryResult) {
+      _fail('Failed to parse "$u"');
+    }
+
+    package.addLibrary(library);
+  }
+
+  // Propogate all exports
+  var changed = true;
+  // Iterate until there are no changes, this is probably not the fastest way to
+  // do this!
+  while (changed) {
+    changed = false;
+    for (final library in package.libraries.values) {
+      library.exports.forEach((exportUri, exportFilter) {
+        // Find the exportLibrary that is exported from library
+        final exportLibrary = package.libraries[exportUri];
+        if (exportLibrary == null) {
+          return;
+        }
+
+        // Everything exported by exportLibrary is also exported from library,
+        // but obviously only when the exportFilter is applied to futher restrict
+        // what is visible.
+        final propogatedExports = exportLibrary.exports.entries.map(
+          (e) => (e.key, e.value.applyFilter(exportFilter)),
+        );
+
+        for (final (uri, filter) in propogatedExports) {
+          final existingFilter = library.exports[uri];
+          if (existingFilter != null) {
+            library.exports[uri] = existingFilter.mergeFilter(filter);
+            // This works because `applyFilter` and `mergeFilter` will return
+            // the existing filter if there are no changes.
+            // Hence, eventually calling `mergeFilter` will just return
+            // `existingFilter`.
+            // TODO: This might require a proof, or something like that. It's
+            //       not entirely trivially obivous.
+            // TODO: We could also build a tree of filters such that each filter
+            //       object have a map to larger filter objects. Effectively,
+            //       we'd have some sort of interning. That would be extremely
+            //       fast, but we'd be unable to free memory. That's probably
+            //       not an issue as we could release it when we're done with
+            //       the analysis :D
+            //       Imagine that NamespaceShowFilter is a linked list, that
+            //       always starts with the empty list. And is always
+            //       alphabetically sorted. Then the set {A, B} would get the
+            //       same node as {B, A}. Obviously, each node would have to
+            //       know which possible successors exists.
+            //       So NamespaceShowFilter would have properties:
+            //         * final String symbol
+            //         * final NamespaceShowFilter? previous
+            //         * final Map<String, NamespaceShowFilter> next
+            //       Given a NamespaceShowFilter object, you'd read [symbol] and
+            //       walk along [previous] until `previous == null`.
+            //       And if you have an NamespaceShowFilter object and want to
+            //       extend it to also show the symbol "foo", then you'd walk
+            //       up [previous] until you see `symbol < "foo"` at which point
+            //       you'd check `next["foo"]` to see if a node already exists
+            //       and if not, create one under there + all the ones necessary
+            //       to represent the full set.
+            //       Or something like that, the idea being that there is a
+            //       only ever a single [NamespaceShowFilter] representing a
+            //       single set, a system where two distint filter objects
+            //       always imply different show sets.
+            //       Probably not performance critical, but could be fun to
+            //       build :D
+            if (library.exports[uri] != existingFilter) {
+              changed = true;
+            }
+          } else {
+            library.exports[uri] = filter;
+            changed = true;
+          }
+          library.exports.update(
+            uri,
+            (existingFilter) => existingFilter.mergeFilter(filter),
+            ifAbsent: () => filter,
+          );
+        }
+        // TODO: Track if anything changed! :D
+      });
+    }
+
+    for (final MapEntry(key: eu, value: ef) in library.exports.entries) {
+      final exportedLibrary = package.libraries[u];
+      if (exportedLibrary == null) {
+        continue;
+      }
+      // Everything exported from exportedLibrary is also exported from library
+      for (final MapEntry(key: u, value: f) in library.exports.entries) {
+        library.exports.update(
+          u,
+          (existingFilter) => existingFilter.mergeFilter(f.applyFilter(ef)),
+          ifAbsent: () => f.applyFilter(ef),
+        );
+      }
+    }
+
+    for (final MapEntry(key: eu, value: ef) in library.exports.entries) {
+      final exportedLibrary = package.libraries[u];
+      if (exportedLibrary == null) {
+        continue;
+      }
+      // Everything exported from exportedLibrary is also exported from library
+      for (final MapEntry(key: u, value: f) in library.exports.entries) {
+        library.exports.update(
+          u,
+          (existingFilter) => existingFilter.mergeFilter(f.applyFilter(ef)),
+          ifAbsent: () => f.applyFilter(ef),
+        );
+      }
+    }
+  }
+
+  return package;
+}
+
+extension on PackageShape {
+  void addLibrary(ParsedLibraryResult library) {
+    final libraryUnit = library.units.where((u) => u.isLibrary).firstOrNull;
+    if (libraryUnit == null) {
+      _fail('Could not find libraryUnit for $library');
+    }
+    // Find the URI for this library
+    final uri = libraryUnit.uri;
+
+    // Check if library shape has been added before, this can happen if a
+    // library has multiple parts.
+    if (libraries[uri] != null) {
+      return;
+    }
+
+    final shape = libraries[uri] = LibraryShape(uri: uri);
+
+    // Extract import / export statements
+    for (final d in library.units.expand((u) => u.unit.directives)) {
+      switch (d) {
+        case ExportDirective d:
+          shape.addExport(d);
+
+        case ImportDirective d:
+          shape.addImport(d);
+
+        case LibraryDirective():
+        case PartDirective() || PartOfDirective():
+        case AugmentationImportDirective() || LibraryAugmentationDirective():
+      }
+    }
+
+    // Find all top-level declarations
+    for (final d in library.units.expand((u) => u.unit.declarations)) {
+      switch (d) {
+        case FunctionDeclaration d:
+          if (d.isGetter || d.isSetter) {
+            if (shape.definedShapes.containsKey(d.nameAsString)) {
+              continue; // we've seen the other getter or setter already
+              // TODO: Check that the other thing we saw was a getter/setter!
+            }
+            final accessors = library.units
+                .expand((u) => u.unit.declarations)
+                .whereType<FunctionDeclaration>()
+                .where((dOther) => d.nameAsString == dOther.nameAsString);
+            shape.define(VariableShape(
+              name: d.nameAsString,
+              hasGetter: accessors.any((a) => a.isGetter),
+              hasSetter: accessors.any((a) => a.isSetter),
+            ));
+          } else {
+            shape.defineFunction(d);
+          }
+
+        case EnumDeclaration d:
+          shape.defineEnum(d);
+
+        case ClassDeclaration d:
+          shape.defineClass(d);
+
+        case MixinDeclaration d:
+          shape.defineMixin(d);
+
+        case ExtensionDeclaration d:
+          shape.defineExtension(d);
+
+        case ClassTypeAlias d:
+          shape.defineClassTypeAlias(d);
+
+        case FunctionTypeAlias d:
+          shape.defineFunctionTypeAlias(d);
+
+        case TopLevelVariableDeclaration d:
+          shape.defineTopLevelVariable(d);
+      }
+    }
+  }
+}
+
+extension on LibraryShape {
+  void addExport(ExportDirective d) {
+    final u = uri.resolve(d.uri.stringValue!);
+    final filter = d.combinators.fold(
+      NamespaceFilter.everything(),
+      (f, c) => f.applyFilter(switch (c) {
+        (ShowCombinator c) => NamespaceShowFilter(c.shownNames.toStringSet()),
+        (HideCombinator c) => NamespaceHideFilter(c.hiddenNames.toStringSet()),
+      }),
+    );
+
+    exports.update(u, (f) => f.mergeFilter(filter), ifAbsent: () => filter);
+  }
+
+  void addImport(ImportDirective d) {
+    final u = uri.resolve(d.uri.stringValue!);
+    final filter = d.combinators.fold(
+      NamespaceFilter.everything(),
+      (f, c) => f.applyFilter(switch (c) {
+        (ShowCombinator c) => NamespaceShowFilter(c.shownNames.toStringSet()),
+        (HideCombinator c) => NamespaceHideFilter(c.hiddenNames.toStringSet()),
+      }),
+    );
+    final prefix = d.prefix?.name ?? '';
+    imports
+        .putIfAbsent(prefix, () => {})
+        .update(u, (f) => f.mergeFilter(filter), ifAbsent: () => filter);
+  }
+
+  void defineFunction(FunctionDeclaration d) {
+    assert(!d.isGetter && !d.isSetter);
+    final parameters = d.functionExpression.parameters!.parameters;
+    define(FunctionShape(
+      name: d.nameAsString,
+      namedParameters: parameters
+          .where((p) => p.isNamed)
+          .map((p) => NamedParameterShape(
+              name: p.name!.value() as String, isRequired: p.isRequired))
+          .toList(),
+      positionalParameters: parameters
+          .where((p) => p.isPositional)
+          .map((p) => PositionalParameterShape(isOptional: p.isOptional))
+          .toList(),
+    ));
+  }
+
+  void defineEnum(EnumDeclaration d) {
+    define(EnumShape(
+      name: d.nameAsString,
+    ));
+  }
+
+  void defineClass(ClassDeclaration d) {
+    define(ClassShape(
+      name: d.nameAsString,
+    ));
+  }
+
+  void defineMixin(MixinDeclaration d) {
+    define(MixinShape(
+      name: d.nameAsString,
+    ));
+  }
+
+  void defineExtension(ExtensionDeclaration d) {
+    final name = d.name?.stringValue;
+    // Ignore unnamed extensions they are not exported, and they cannot
+    // influence the existence of other names.
+    if (name != null) {
+      define(ExtensionShape(
+        name: name,
+      ));
+    }
+  }
+
+  void defineClassTypeAlias(ClassTypeAlias d) {
+    define(ClassTypeAliasShape(
+      name: d.nameAsString,
+    ));
+  }
+
+  void defineFunctionTypeAlias(FunctionTypeAlias d) {
+    define(FunctionTypeAliasShape(
+      name: d.nameAsString,
+    ));
+  }
+
+  void defineTopLevelVariable(TopLevelVariableDeclaration d) {
+    for (final v in d.variables.variables) {
+      final name = v.name.value();
+      if (name is! String) {
+        throw _fail('Unnamed variable $v');
+      }
+      define(VariableShape(
+        name: name,
+        hasGetter: true,
+        hasSetter: !d.variables.isConst && !d.variables.isFinal,
+      ));
+    }
+  }
+
+  void define(LibraryMemberShape shape) {
+    if (definedShapes.containsKey(shape.name)) {
+      _fail('${shape.name} is defined more than once!');
+    }
+    definedShapes[shape.name] = shape;
+  }
+}
+
+extension on NamedCompilationUnitMember {
+  String get nameAsString {
+    final n = name.value();
+    if (n is! String) {
+      _fail('Top-level member has no name: $this');
+    }
+    return n;
+  }
+}
+
+extension on NodeList<SimpleIdentifier> {
+  Set<String> toStringSet() => map((i) => i.name).toSet();
+}
+
+extension on Uri {
+  /// True, if this [Uri] points to a resource in [package].
+  bool isInPackage(String package) =>
+      isScheme('package') && pathSegments.firstOrNull == package;
+}

--- a/api_analysis/lib/r3/analyze.dart
+++ b/api_analysis/lib/r3/analyze.dart
@@ -29,7 +29,8 @@ import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-import '../common.dart' show LanguageVersionCompatibilityExt, fail;
+import '../common.dart'
+    show LanguageVersionCompatibilityExt, fail, PackageSchemeExt;
 import '../pubapi.dart';
 import 'shapes.dart';
 
@@ -409,10 +410,4 @@ extension on NamedCompilationUnitMember {
 
 extension on NodeList<SimpleIdentifier> {
   Set<String> toStringSet() => map((i) => i.name).toSet();
-}
-
-extension on Uri {
-  /// True, if this [Uri] points to a resource in [package].
-  bool isInPackage(String package) =>
-      isScheme('package') && pathSegments.firstOrNull == package;
 }

--- a/api_analysis/lib/r3/analyze.dart
+++ b/api_analysis/lib/r3/analyze.dart
@@ -289,16 +289,16 @@ extension on PackageShape {
       switch (d) {
         case FunctionDeclaration d:
           if (d.isGetter || d.isSetter) {
-            if (shape.definedShapes.containsKey(d.nameAsString)) {
+            if (shape.definedShapes.containsKey(d.name.lexeme)) {
               continue; // we've seen the other getter or setter already
               // TODO: Check that the other thing we saw was a getter/setter!
             }
             final accessors = library.units
                 .expand((u) => u.unit.declarations)
                 .whereType<FunctionDeclaration>()
-                .where((dOther) => d.nameAsString == dOther.nameAsString);
+                .where((dOther) => d.name.lexeme == dOther.name.lexeme);
             shape.define(VariableShape(
-              name: d.nameAsString,
+              name: d.name.lexeme,
               hasGetter: accessors.any((a) => a.isGetter),
               hasSetter: accessors.any((a) => a.isSetter),
             ));
@@ -425,19 +425,19 @@ extension on LibraryShape {
 
   void defineEnum(EnumDeclaration d) {
     define(EnumShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
     ));
   }
 
   void defineClass(ClassDeclaration d) {
     define(ClassShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
     ));
   }
 
   void defineMixin(MixinDeclaration d) {
     define(MixinShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
     ));
   }
 
@@ -454,13 +454,13 @@ extension on LibraryShape {
 
   void defineClassTypeAlias(ClassTypeAlias d) {
     define(ClassTypeAliasShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
     ));
   }
 
   void defineFunctionTypeAlias(FunctionTypeAlias d) {
     define(FunctionTypeAliasShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
     ));
   }
 
@@ -483,16 +483,6 @@ extension on LibraryShape {
       fail('${shape.name} is defined more than once!');
     }
     definedShapes[shape.name] = shape;
-  }
-}
-
-extension on NamedCompilationUnitMember {
-  String get nameAsString {
-    final n = name.value();
-    if (n is! String) {
-      fail('Top-level member has no name: $this');
-    }
-    return n;
   }
 }
 

--- a/api_analysis/lib/r3/analyze.dart
+++ b/api_analysis/lib/r3/analyze.dart
@@ -262,11 +262,11 @@ extension on LibraryShape {
     assert(!d.isGetter && !d.isSetter);
     final parameters = d.functionExpression.parameters!.parameters;
     define(FunctionShape(
-      name: d.nameAsString,
+      name: d.name.lexeme,
       namedParameters: parameters
           .where((p) => p.isNamed)
           .map((p) => NamedParameterShape(
-              name: p.name!.value() as String, isRequired: p.isRequired))
+              name: p.name!.lexeme, isRequired: p.isRequired))
           .toList(),
       positionalParameters: parameters
           .where((p) => p.isPositional)

--- a/api_analysis/lib/r3/outline.dart
+++ b/api_analysis/lib/r3/outline.dart
@@ -1,0 +1,100 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Outline of a package that can be serialized to JSON and used on-the-fly when
+/// aiming to check if an older version of a package contains an identifier that
+/// is being used.
+/// In this scenario you'd have a [PackageOutline] of the older version, and
+/// an analysis session with resolved dependencies for the current version.
+library;
+
+import 'package:pub_semver/pub_semver.dart';
+
+// TODO: Don't call these object Outline or Summary these words are already used!
+
+final class PackageOutline {
+  String get name => throw UnimplementedError();
+  Version get version => throw UnimplementedError();
+
+  /// List of public libraries in this package.
+  ///
+  /// This does not include libraries from `lib/src/`.
+  Iterable<LibraryOutline> get libraries => throw UnimplementedError();
+}
+
+final class LibraryOutline {
+  /// Uri for this library, on the form `package:<package>/path/to/file.dart`.
+  Uri get uri => throw UnimplementedError();
+
+  /// List of exported elements.
+  ///
+  /// This includes all public top-level elements defined in this library, and
+  /// elements exported from other libraries in this package.
+  Iterable<LibraryElementOutline> get elements => throw UnimplementedError();
+}
+
+sealed class LibraryElementOutline {
+  final String name;
+
+  /// List of libraries that that this element is exported from.
+  ///
+  /// TODO: Unclear if we need this? it might be the best/only way to find out
+  ///       which Foo is the same between two package versions.
+  Iterable<LibraryOutline> get exportedFrom => throw UnimplementedError();
+
+  LibraryElementOutline({required this.name});
+}
+
+final class FunctionOutline extends LibraryElementOutline {
+  // TODO: Add outline of position and named parameters.
+
+  FunctionOutline({
+    required super.name,
+  });
+}
+
+final class EnumOutline extends LibraryElementOutline {
+  EnumOutline({required super.name});
+}
+
+final class ClassOutline extends LibraryElementOutline {
+  ClassOutline({required super.name});
+}
+
+final class MixinOutline extends LibraryElementOutline {
+  MixinOutline({required super.name});
+}
+
+final class ExtensionOutline extends LibraryElementOutline {
+  ExtensionOutline({required super.name});
+}
+
+final class FunctionTypeAliasOutline extends LibraryElementOutline {
+  FunctionTypeAliasOutline({required super.name});
+}
+
+final class ClassTypeAliasOutline extends LibraryElementOutline {
+  ClassTypeAliasOutline({required super.name});
+}
+
+final class VariableOutline extends LibraryElementOutline {
+  final bool hasGetter;
+  final bool hasSetter;
+
+  VariableOutline({
+    required super.name,
+    required this.hasGetter,
+    required this.hasSetter,
+  });
+}

--- a/api_analysis/lib/r3/shapes.dart
+++ b/api_analysis/lib/r3/shapes.dart
@@ -17,8 +17,11 @@
 library;
 
 import 'package:collection/collection.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
+
+part 'shapes.g.dart';
 
 bool Function(List<dynamic>?, List<dynamic>?) listEquals =
     const ListEquality().equals;
@@ -32,6 +35,13 @@ class PackageShape {
     required this.name,
     required this.version,
   });
+
+  Map<String, dynamic> toJsonNormalSummary() => Map.fromEntries(
+        libraries.entries.sortedBy((e) => e.key.toString()).map((e) => MapEntry(
+              e.key.toString(),
+              e.value.toJsonNormalSummary(),
+            )),
+      );
 }
 
 class LibraryShape {
@@ -60,6 +70,17 @@ class LibraryShape {
   final Map<String, LibraryMemberShape> importedShapes = {};
 
   LibraryShape({required this.uri});
+
+  Map<String, dynamic> toJsonNormalSummary() {
+    final result = <String, dynamic>{'uri': uri.toString()};
+    result.addEntries(
+      exportedShapes.entries.sortedBy((e) => e.key).map((e) => MapEntry(
+            e.key,
+            e.value.toJson(),
+          )),
+    );
+    return result;
+  }
 }
 
 /// A filter on an imported namespace in the form of `show ... hide ...`.
@@ -243,8 +264,11 @@ sealed class LibraryMemberShape {
   @override
   @mustBeOverridden
   bool operator ==(Object other);
+
+  Map<String, dynamic> toJson();
 }
 
+@JsonSerializable()
 final class FunctionShape extends LibraryMemberShape {
   final List<PositionalParameterShape> positionalParameters;
   final List<NamedParameterShape> namedParameters;
@@ -269,8 +293,15 @@ final class FunctionShape extends LibraryMemberShape {
         Object.hashAll(positionalParameters),
         Object.hashAll(namedParameters),
       );
+
+  factory FunctionShape.fromJson(Map<String, dynamic> json) =>
+      _$FunctionShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$FunctionShapeToJson(this);
 }
 
+@JsonSerializable()
 final class EnumShape extends LibraryMemberShape {
   EnumShape({required super.name});
 
@@ -280,8 +311,15 @@ final class EnumShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory EnumShape.fromJson(Map<String, dynamic> json) =>
+      _$EnumShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$EnumShapeToJson(this);
 }
 
+@JsonSerializable()
 final class ClassShape extends LibraryMemberShape {
   ClassShape({required super.name});
 
@@ -291,8 +329,15 @@ final class ClassShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory ClassShape.fromJson(Map<String, dynamic> json) =>
+      _$ClassShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$ClassShapeToJson(this);
 }
 
+@JsonSerializable()
 final class MixinShape extends LibraryMemberShape {
   MixinShape({required super.name});
 
@@ -302,8 +347,15 @@ final class MixinShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory MixinShape.fromJson(Map<String, dynamic> json) =>
+      _$MixinShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$MixinShapeToJson(this);
 }
 
+@JsonSerializable()
 final class ExtensionShape extends LibraryMemberShape {
   ExtensionShape({required super.name});
 
@@ -313,8 +365,15 @@ final class ExtensionShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory ExtensionShape.fromJson(Map<String, dynamic> json) =>
+      _$ExtensionShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$ExtensionShapeToJson(this);
 }
 
+@JsonSerializable()
 final class FunctionTypeAliasShape extends LibraryMemberShape {
   FunctionTypeAliasShape({required super.name});
 
@@ -325,8 +384,15 @@ final class FunctionTypeAliasShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory FunctionTypeAliasShape.fromJson(Map<String, dynamic> json) =>
+      _$FunctionTypeAliasShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$FunctionTypeAliasShapeToJson(this);
 }
 
+@JsonSerializable()
 final class ClassTypeAliasShape extends LibraryMemberShape {
   ClassTypeAliasShape({required super.name});
 
@@ -337,8 +403,15 @@ final class ClassTypeAliasShape extends LibraryMemberShape {
 
   @override
   int get hashCode => name.hashCode;
+
+  factory ClassTypeAliasShape.fromJson(Map<String, dynamic> json) =>
+      _$ClassTypeAliasShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$ClassTypeAliasShapeToJson(this);
 }
 
+@JsonSerializable()
 final class VariableShape extends LibraryMemberShape {
   final bool hasGetter;
   final bool hasSetter;
@@ -359,8 +432,15 @@ final class VariableShape extends LibraryMemberShape {
 
   @override
   int get hashCode => Object.hash(name, hasGetter, hasSetter);
+
+  factory VariableShape.fromJson(Map<String, dynamic> json) =>
+      _$VariableShapeFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$VariableShapeToJson(this);
 }
 
+@JsonSerializable()
 final class PositionalParameterShape {
   final bool isOptional;
 
@@ -375,8 +455,12 @@ final class PositionalParameterShape {
 
   @override
   int get hashCode => isOptional.hashCode;
+  factory PositionalParameterShape.fromJson(Map<String, dynamic> json) =>
+      _$PositionalParameterShapeFromJson(json);
+  Map<String, dynamic> toJson() => _$PositionalParameterShapeToJson(this);
 }
 
+@JsonSerializable()
 final class NamedParameterShape {
   final String name;
   final bool isRequired;
@@ -395,6 +479,9 @@ final class NamedParameterShape {
 
   @override
   int get hashCode => Object.hash(name, isRequired);
+  factory NamedParameterShape.fromJson(Map<String, dynamic> json) =>
+      _$NamedParameterShapeFromJson(json);
+  Map<String, dynamic> toJson() => _$NamedParameterShapeToJson(this);
 }
 
 extension LibraryMemberShapeGetters on LibraryMemberShape {

--- a/api_analysis/lib/r3/shapes.dart
+++ b/api_analysis/lib/r3/shapes.dart
@@ -1,0 +1,303 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Intermediate data-structures for collection of data from an unresolved AST
+/// inorder to eventually produce a `PackageOutline`.
+library;
+
+import 'dart:collection';
+
+import 'package:pub_semver/pub_semver.dart';
+
+class PackageShape {
+  final String name;
+  final Version version;
+  final Map<Uri, LibraryShape> libraries = {};
+
+  PackageShape({
+    required this.name,
+    required this.version,
+  });
+}
+
+class LibraryShape {
+  final Uri uri;
+
+  /// Map from prefix to map from imported [Uri] to namespace filter applied.
+  ///
+  /// The empty prefix / key points to libraries imported without any prefix.
+  final Map<String, Map<Uri, NamespaceFilter>> imports = {};
+  final Map<Uri, NamespaceFilter> exports = {};
+
+  /// Top-level elements defined in this library.
+  final Map<String, LibraryMemberShape> definedShapes = {};
+
+  /// Top-level elements exported from this library.
+  ///
+  /// This includes all shapes exported from `export` statements pointing to
+  /// other libraries in this package.
+  final Map<String, LibraryMemberShape> exportedShapes = {};
+
+  /// Top-level elements imported into this library.
+  ///
+  /// For prefixed imports the key will include the prefix.
+  /// This includes all shapes imported from `import` statements pointing to
+  /// other libaries in this package.
+  final Map<String, LibraryMemberShape> importedShapes = {};
+
+  LibraryShape({required this.uri});
+}
+
+/// A filter on an imported namespace in the form of `show ... hide ...`.
+sealed class NamespaceFilter {
+  const NamespaceFilter();
+
+  /// A filter that shows everything in a namespace.
+  ///
+  /// In other words a [NamespaceHideFilter] that doesn't hide anything.
+  factory NamespaceFilter.everything() => NamespaceHideFilter._everything();
+
+  /// A filter that shows nothing from a namespace.
+  ///
+  /// In other words a [NamespaceShowFilter] that doesn't show anything.
+  factory NamespaceFilter.nothing() => NamespaceShowFilter._nothing();
+
+  /// Apply a further filter.
+  ///
+  /// This will only create a new [NamespaceFilter] object, if it's different
+  /// from this and [other].
+  NamespaceFilter applyFilter(NamespaceFilter other);
+
+  /// Create a filter that represents both filters applied in parallel.
+  ///
+  /// This will only create a new [NamespaceFilter] object, if it's different
+  /// from this and [other].
+  NamespaceFilter mergeFilter(NamespaceFilter other);
+
+  /// Is [symbol] visible once this filter is applied?
+  bool isVisible(String symbol);
+
+  /// `true`, if this filter is known to be empty.
+  ///
+  /// The filter might be empty when applied against a set of known symbols.
+  /// This is only true, if it's trivial to determine that the filter is empty.
+  bool get isTriviallyEmpty;
+}
+
+/// Filter on an imported/exported namespace on the form `show foo, bar, ...`
+final class NamespaceShowFilter extends NamespaceFilter {
+  Set<String> get show => UnmodifiableSetView(_show);
+  final Set<String> _show;
+
+  factory NamespaceShowFilter._nothing() => const NamespaceShowFilter._({});
+
+  factory NamespaceShowFilter(Set<String> show) {
+    if (show.isEmpty) {
+      return NamespaceShowFilter._nothing();
+    }
+    return NamespaceShowFilter._(show);
+  }
+  const NamespaceShowFilter._(this._show);
+
+  @override
+  NamespaceFilter applyFilter(NamespaceFilter other) {
+    switch (other) {
+      case NamespaceShowFilter other:
+        final intersection = _show.intersection(other._show);
+        if (intersection.length == _show.length) {
+          // If nothings are the same, then there is no need to create a new
+          // NamespaceShowFilter object, we can just return this one!
+          return this;
+        }
+        if (intersection.length == other._show.length) {
+          return other;
+        }
+        return NamespaceShowFilter(intersection);
+      case NamespaceHideFilter other:
+        final difference = _show.difference(other._hide);
+        if (difference.length == _show.length) {
+          return this;
+        }
+        return NamespaceShowFilter(difference);
+    }
+  }
+
+  @override
+  NamespaceFilter mergeFilter(NamespaceFilter other) {
+    switch (other) {
+      case NamespaceShowFilter other:
+        final union = _show.union(other._show);
+        if (union.length == _show.length) {
+          return this;
+        }
+        if (union.length == other.show.length) {
+          return other;
+        }
+        return NamespaceShowFilter(union);
+      case NamespaceHideFilter other:
+        final difference = other._hide.difference(_show);
+        if (difference.length == other._hide.length) {
+          return other;
+        }
+        return NamespaceHideFilter(difference);
+    }
+  }
+
+  @override
+  bool isVisible(String symbol) => _show.contains(symbol);
+
+  @override
+  bool get isTriviallyEmpty => _show.isEmpty;
+}
+
+/// Filter on an imported/exported namespace on the form `hide foo, bar, ...`
+final class NamespaceHideFilter extends NamespaceFilter {
+  Set<String> get hide => UnmodifiableSetView(_hide);
+  final Set<String> _hide;
+
+  factory NamespaceHideFilter._everything() => const NamespaceHideFilter._({});
+
+  factory NamespaceHideFilter(Set<String> hide) {
+    if (hide.isEmpty) {
+      return NamespaceHideFilter._everything();
+    }
+    return NamespaceHideFilter._(hide);
+  }
+
+  const NamespaceHideFilter._(this._hide);
+
+  @override
+  NamespaceFilter applyFilter(NamespaceFilter other) {
+    switch (other) {
+      case NamespaceShowFilter other:
+        final difference = other._show.difference(_hide);
+        if (difference.length == other._show.length) {
+          return other;
+        }
+        return NamespaceShowFilter(difference);
+      case NamespaceHideFilter other:
+        final union = _hide.union(other._hide);
+        if (union.length == _hide.length) {
+          return this;
+        }
+        if (union.length == other._hide.length) {
+          return other;
+        }
+        return NamespaceHideFilter(union);
+    }
+  }
+
+  @override
+  NamespaceFilter mergeFilter(NamespaceFilter other) {
+    switch (other) {
+      case NamespaceShowFilter other:
+        final difference = _hide.difference(other._show);
+        if (difference.length == _hide.length) {
+          return this;
+        }
+        return NamespaceHideFilter(difference);
+      case NamespaceHideFilter other:
+        final intersection = _hide.intersection(other._hide);
+        if (intersection.length == _hide.length) {
+          return this;
+        }
+        if (intersection.length == other._hide.length) {
+          return other;
+        }
+        return NamespaceHideFilter(intersection);
+    }
+  }
+
+  @override
+  bool isVisible(String symbol) => !_hide.contains(symbol);
+
+  @override
+  bool get isTriviallyEmpty => false;
+}
+
+sealed class LibraryMemberShape {
+  final String name;
+
+  LibraryMemberShape({
+    required this.name,
+  });
+}
+
+final class FunctionShape extends LibraryMemberShape {
+  final List<PositionalParameterShape> positionalParameters;
+  final List<NamedParameterShape> namedParameters;
+
+  FunctionShape({
+    required super.name,
+    required this.positionalParameters,
+    required this.namedParameters,
+  });
+}
+
+final class EnumShape extends LibraryMemberShape {
+  EnumShape({required super.name});
+}
+
+final class ClassShape extends LibraryMemberShape {
+  ClassShape({required super.name});
+}
+
+final class MixinShape extends LibraryMemberShape {
+  MixinShape({required super.name});
+}
+
+final class ExtensionShape extends LibraryMemberShape {
+  ExtensionShape({required super.name});
+}
+
+final class FunctionTypeAliasShape extends LibraryMemberShape {
+  FunctionTypeAliasShape({required super.name});
+}
+
+final class ClassTypeAliasShape extends LibraryMemberShape {
+  ClassTypeAliasShape({required super.name});
+}
+
+final class VariableShape extends LibraryMemberShape {
+  final bool hasGetter;
+  final bool hasSetter;
+
+  VariableShape({
+    required super.name,
+    required this.hasGetter,
+    required this.hasSetter,
+  });
+}
+
+final class PositionalParameterShape {
+  final bool isOptional;
+
+  PositionalParameterShape({
+    required this.isOptional,
+  });
+}
+
+final class NamedParameterShape {
+  final String name;
+  final bool isRequired;
+
+  NamedParameterShape({
+    required this.name,
+    required this.isRequired,
+  });
+}
+
+extension LibraryMemberShapeGetters on LibraryMemberShape {
+  bool get isPrivate => name.startsWith('_');
+}

--- a/api_analysis/lib/r3/shapes.dart
+++ b/api_analysis/lib/r3/shapes.dart
@@ -16,9 +16,12 @@
 /// inorder to eventually produce a `PackageOutline`.
 library;
 
-import 'dart:collection';
-
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
+
+bool Function(List<dynamic>?, List<dynamic>?) listEquals =
+    const ListEquality().equals;
 
 class PackageShape {
   final String name;
@@ -232,6 +235,14 @@ sealed class LibraryMemberShape {
   LibraryMemberShape({
     required this.name,
   });
+
+  @override
+  @mustBeOverridden
+  int get hashCode;
+
+  @override
+  @mustBeOverridden
+  bool operator ==(Object other);
 }
 
 final class FunctionShape extends LibraryMemberShape {
@@ -243,30 +254,89 @@ final class FunctionShape extends LibraryMemberShape {
     required this.positionalParameters,
     required this.namedParameters,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FunctionShape &&
+          name == other.name &&
+          listEquals(positionalParameters, other.positionalParameters) &&
+          listEquals(namedParameters, other.namedParameters);
+
+  @override
+  int get hashCode => Object.hash(
+        name,
+        Object.hashAll(positionalParameters),
+        Object.hashAll(namedParameters),
+      );
 }
 
 final class EnumShape extends LibraryMemberShape {
   EnumShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is EnumShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class ClassShape extends LibraryMemberShape {
   ClassShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ClassShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class MixinShape extends LibraryMemberShape {
   MixinShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is MixinShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class ExtensionShape extends LibraryMemberShape {
   ExtensionShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is ExtensionShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class FunctionTypeAliasShape extends LibraryMemberShape {
   FunctionTypeAliasShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FunctionTypeAliasShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class ClassTypeAliasShape extends LibraryMemberShape {
   ClassTypeAliasShape({required super.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ClassTypeAliasShape && name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
 }
 
 final class VariableShape extends LibraryMemberShape {
@@ -278,6 +348,17 @@ final class VariableShape extends LibraryMemberShape {
     required this.hasGetter,
     required this.hasSetter,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VariableShape &&
+          name == other.name &&
+          hasGetter == other.hasGetter &&
+          hasSetter == other.hasSetter;
+
+  @override
+  int get hashCode => Object.hash(name, hasGetter, hasSetter);
 }
 
 final class PositionalParameterShape {
@@ -286,6 +367,14 @@ final class PositionalParameterShape {
   PositionalParameterShape({
     required this.isOptional,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PositionalParameterShape && isOptional == other.isOptional;
+
+  @override
+  int get hashCode => isOptional.hashCode;
 }
 
 final class NamedParameterShape {
@@ -296,6 +385,16 @@ final class NamedParameterShape {
     required this.name,
     required this.isRequired,
   });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NamedParameterShape &&
+          name == other.name &&
+          isRequired == other.isRequired;
+
+  @override
+  int get hashCode => Object.hash(name, isRequired);
 }
 
 extension LibraryMemberShapeGetters on LibraryMemberShape {

--- a/api_analysis/lib/r3/shapes.dart
+++ b/api_analysis/lib/r3/shapes.dart
@@ -36,11 +36,22 @@ class PackageShape {
     required this.version,
   });
 
-  Map<String, dynamic> toJsonNormalSummary() => Map.fromEntries(
-        libraries.entries.sortedBy((e) => e.key.toString()).map((e) => MapEntry(
-              e.key.toString(),
-              e.value.toJsonNormalSummary(),
-            )),
+  Map<String, dynamic> toJsonNormalPublicSummary() => Map.fromEntries(
+        libraries.entries
+            .where((e) {
+              // Do not include private libraries in the summary.
+              if (e.key.pathSegments.length >= 2 &&
+                  e.key.pathSegments[1] == 'src') {
+                assert(e.key.pathSegments.length >= 3);
+                return false;
+              }
+              return true;
+            })
+            .sortedBy((e) => e.key.toString())
+            .map((e) => MapEntry(
+                  e.key.toString(),
+                  e.value.toJsonNormalSummary(),
+                )),
       );
 }
 

--- a/api_analysis/lib/r3/shapes.dart
+++ b/api_analysis/lib/r3/shapes.dart
@@ -21,6 +21,8 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../common.dart' show PackageSchemeExt;
+
 part 'shapes.g.dart';
 
 bool Function(List<dynamic>?, List<dynamic>?) listEquals =
@@ -38,15 +40,7 @@ class PackageShape {
 
   Map<String, dynamic> toJsonNormalPublicSummary() => Map.fromEntries(
         libraries.entries
-            .where((e) {
-              // Do not include private libraries in the summary.
-              if (e.key.pathSegments.length >= 2 &&
-                  e.key.pathSegments[1] == 'src') {
-                assert(e.key.pathSegments.length >= 3);
-                return false;
-              }
-              return true;
-            })
+            .where((e) => !e.key.isInPrivateLibrary)
             .sortedBy((e) => e.key.toString())
             .map((e) => MapEntry(
                   e.key.toString(),

--- a/api_analysis/lib/r3/shapes.g.dart
+++ b/api_analysis/lib/r3/shapes.g.dart
@@ -1,0 +1,124 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'shapes.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FunctionShape _$FunctionShapeFromJson(Map<String, dynamic> json) =>
+    FunctionShape(
+      name: json['name'] as String,
+      positionalParameters: (json['positionalParameters'] as List<dynamic>)
+          .map((e) =>
+              PositionalParameterShape.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      namedParameters: (json['namedParameters'] as List<dynamic>)
+          .map((e) => NamedParameterShape.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$FunctionShapeToJson(FunctionShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'positionalParameters': instance.positionalParameters,
+      'namedParameters': instance.namedParameters,
+    };
+
+EnumShape _$EnumShapeFromJson(Map<String, dynamic> json) => EnumShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$EnumShapeToJson(EnumShape instance) => <String, dynamic>{
+      'name': instance.name,
+    };
+
+ClassShape _$ClassShapeFromJson(Map<String, dynamic> json) => ClassShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$ClassShapeToJson(ClassShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+MixinShape _$MixinShapeFromJson(Map<String, dynamic> json) => MixinShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$MixinShapeToJson(MixinShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+ExtensionShape _$ExtensionShapeFromJson(Map<String, dynamic> json) =>
+    ExtensionShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$ExtensionShapeToJson(ExtensionShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+FunctionTypeAliasShape _$FunctionTypeAliasShapeFromJson(
+        Map<String, dynamic> json) =>
+    FunctionTypeAliasShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$FunctionTypeAliasShapeToJson(
+        FunctionTypeAliasShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+ClassTypeAliasShape _$ClassTypeAliasShapeFromJson(Map<String, dynamic> json) =>
+    ClassTypeAliasShape(
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$ClassTypeAliasShapeToJson(
+        ClassTypeAliasShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+    };
+
+VariableShape _$VariableShapeFromJson(Map<String, dynamic> json) =>
+    VariableShape(
+      name: json['name'] as String,
+      hasGetter: json['hasGetter'] as bool,
+      hasSetter: json['hasSetter'] as bool,
+    );
+
+Map<String, dynamic> _$VariableShapeToJson(VariableShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'hasGetter': instance.hasGetter,
+      'hasSetter': instance.hasSetter,
+    };
+
+PositionalParameterShape _$PositionalParameterShapeFromJson(
+        Map<String, dynamic> json) =>
+    PositionalParameterShape(
+      isOptional: json['isOptional'] as bool,
+    );
+
+Map<String, dynamic> _$PositionalParameterShapeToJson(
+        PositionalParameterShape instance) =>
+    <String, dynamic>{
+      'isOptional': instance.isOptional,
+    };
+
+NamedParameterShape _$NamedParameterShapeFromJson(Map<String, dynamic> json) =>
+    NamedParameterShape(
+      name: json['name'] as String,
+      isRequired: json['isRequired'] as bool,
+    );
+
+Map<String, dynamic> _$NamedParameterShapeToJson(
+        NamedParameterShape instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'isRequired': instance.isRequired,
+    };

--- a/api_analysis/pubspec.yaml
+++ b/api_analysis/pubspec.yaml
@@ -10,11 +10,15 @@ dependencies:
   async: ^2.11.0
   collection: ^1.18.0
   http: ^1.1.0
+  json_annotation: ^4.8.1
+  meta: ^1.9.1
   pub_semver: ^2.1.4
   pubspec_parse: ^1.2.3
   retry: ^3.1.2
   tar: ^1.0.1
 
 dev_dependencies:
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.1
   lints: ^2.0.0
   test: ^1.16.0


### PR DESCRIPTION
This includes propagation of exports, so the summary produced should be fairly comprehensive.

One can analyse a local package to obtain a full summary, or a hosted package, in which case all appropriate versions are analysed and the differences displayed.

It remains to add a README description.