### PR TITLE
pem: Bump petitparser from 5.1.0 to 6.0.2

### DIFF
--- a/pem/pubspec.yaml
+++ b/pem/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pem
-version: 2.0.4
+version: 2.0.5
 description: >-
   PEM encoding/decoding of textual keys following RFC 7468,
   supporting both lax/strict-mode, and certificates chains of concatenated
@@ -13,10 +13,10 @@ topics:
  - parser
  - pem
 dependencies:
-  petitparser: ^5.1.0
+  petitparser: ^6.0.2
 dev_dependencies:
   test: ^1.16.5
-  lints: ^1.0.0
+  lints: ^3.0.0
 environment:
   sdk: '>=2.12.0 <3.0.0'
 false_secrets:

--- a/pem/pubspec.yaml
+++ b/pem/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
  - parser
  - pem
 dependencies:
-  petitparser: ^6.0.2
+  petitparser: '>=5.1.0 <7.0.0'
 dev_dependencies:
   test: ^1.16.5
   lints: ^3.0.0


### PR DESCRIPTION
This PR changes `pem` package:
- updates version of dependency `petitparser` from 5.1.0 to 6.0.2;
- updates version of dev dependency `lints` from 1.0.0 to 3.0.0;