### PR TITLE
Reconnect when a redis command fails

### DIFF
--- a/neat_cache/CHANGELOG.md
+++ b/neat_cache/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.4
+ * Reconnect when a redis command fails.
+
 ## v2.0.3
  * Added `topics` to `pubspec.yaml`.
 

--- a/neat_cache/pubspec.yaml
+++ b/neat_cache/pubspec.yaml
@@ -1,5 +1,5 @@
 name: neat_cache
-version: 2.0.3
+version: 2.0.4
 description: >-
   A neat cache abstraction for wrapping in-memory or redis caches.
 homepage: https://github.com/google/dart-neats/tree/master/neat_cache


### PR DESCRIPTION
We have seen cases with:
> RedisCommandException: OOM command not allowed under OOM prevention

Basically, we're getting an `OOM` error to a get/set command, this can happen if the system runs out of memory. Even if cache-eviction is enabled, memory can be fragmented too much, or other bad thing.

Conclusion was that commands like `get/set` can fail, even when redis is just used as a cache. There is no really good way to handle it. It might be safest to simply close the connection and try again later.