### PR TITLE
vendor: Dart CI Failing Fix

### DIFF
--- a/vendor/pubspec.yaml
+++ b/vendor/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   path: ^1.8.0
   logging: ^1.0.2
   io: ^1.0.3
-  tar: ^0.5.1
+  tar: ^2.0.0
   pubspec_parse: ^1.2.0
 dev_dependencies:
   shelf: ^1.2.0
@@ -35,6 +35,6 @@ dev_dependencies:
   build_runner: ^2.1.4
   build_version: ^2.1.0
   chunked_stream: ^1.4.1
-  lints: ^2.0.1
+  lints: ^5.0.0
 environment:
   sdk: '>=2.14.0 <3.0.0'

--- a/vendor/test/pub_test_server.dart
+++ b/vendor/test/pub_test_server.dart
@@ -131,13 +131,14 @@ Stream<TarEntry> _descriptorToTarEntries(
     if (descriptor is d.FileDescriptor) {
       final data = await collectBytes(descriptor.readAsBytes());
       yield TarEntry.data(
-        TarHeader(name: path, size: data.length),
+        TarHeader(name: path, mode: 0, size: data.length),
         data,
       );
     } else if (descriptor is d.DirectoryDescriptor) {
       yield TarEntry.data(
         TarHeader(
           name: path,
+          mode: 0,
           typeFlag: TypeFlag.dir,
         ),
         [],


### PR DESCRIPTION
Dart CI Failing due to Tar Package in Vendor.

Upgrade Dart packages: 

tar: ^0.5.1 ->  tar: ^2.0.0
lints: ^2.0.1 -> lints: ^5.0.0