### PR TITLE
Support for postgres BC datetimes, notably `DateTime.utc(0)`

### DIFF
--- a/typed_sql/CHANGELOG.md
+++ b/typed_sql/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.1.3-wip
  * Added `TransactionAbortedException.toString()` to render the `reason` when
    printing an exception.
+ * Fix postgres support for `DateTime.utc(0)`, which must be encoded as 'BC'
+   suffixed date-time.
 
 ## 0.1.2
  * Support for _composite foreign keys_ using the `@ForeignKey` annotation.

--- a/typed_sql/lib/src/adapter/postgres_adapter.dart
+++ b/typed_sql/lib/src/adapter/postgres_adapter.dart
@@ -451,6 +451,10 @@ final class _PostgresRowReader extends RowReader {
 
 List<Object?> _paramsForPostgres(List<Object?> params) => params
     .map((p) => switch (p) {
+          // Negative years and year zero most be written as BC in postgres
+          // https://www.postgresql.org/docs/17/datetime-input-rules.html
+          DateTime d when d.year <= 0 =>
+            '${d.copyWith(year: 1 - d.year).toIso8601String()} BC',
           DateTime d => d.toIso8601String(),
           String s => s,
           null => null,

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = Uint8List.fromList([1, 2, 3]);
   final updatedValue = Uint8List.fromList([1, 2, 3, 4]);
+  final emptyValue = Uint8List.fromList([]);
+  final otherValue = Uint8List.fromList([0]);
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.deepEquals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = true;
   final updatedValue = false;
+  final emptyValue = false;
+  final otherValue = true;
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.equals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = DateTime(2024).toUtc();
   final updatedValue = DateTime(2025).toUtc();
+  final emptyValue = DateTime.utc(0);
+  final otherValue = DateTime.utc(-5);
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.equals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = 42;
   final updatedValue = 21;
+  final emptyValue = 0;
+  final otherValue = -5;
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.equals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/test/typed_sql/crud/real/real_test.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = 42.2;
   final updatedValue = 43.2;
+  final emptyValue = 0.0;
+  final otherValue = -5.2;
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.equals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/test/typed_sql/crud/text/text_test.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.dart
@@ -32,6 +32,8 @@ void main() {
 
   final initialValue = 'hello';
   final updatedValue = 'hello world';
+  final emptyValue = '';
+  final otherValue = '-';
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -43,6 +45,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.equals(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {

--- a/typed_sql/tool/generate_crud_tests.dart
+++ b/typed_sql/tool/generate_crud_tests.dart
@@ -44,6 +44,8 @@ final instances = [
     'type': 'int',
     'initialValue': '42',
     'updatedValue': '21',
+    'emptyValue': '0',
+    'otherValue': '-5',
     'equality': 'equals',
   },
   {
@@ -51,6 +53,8 @@ final instances = [
     'type': 'String',
     'initialValue': '\'hello\'',
     'updatedValue': '\'hello world\'',
+    'emptyValue': '\'\'',
+    'otherValue': '\'-\'',
     'equality': 'equals',
   },
   {
@@ -58,6 +62,8 @@ final instances = [
     'type': 'bool',
     'initialValue': 'true',
     'updatedValue': 'false',
+    'emptyValue': 'false',
+    'otherValue': 'true',
     'equality': 'equals',
   },
   {
@@ -65,6 +71,8 @@ final instances = [
     'type': 'double',
     'initialValue': '42.2',
     'updatedValue': '43.2',
+    'emptyValue': '0.0',
+    'otherValue': '-5.2',
     'equality': 'equals',
   },
   {
@@ -72,6 +80,10 @@ final instances = [
     'type': 'DateTime',
     'initialValue': 'DateTime(2024).toUtc()',
     'updatedValue': 'DateTime(2025).toUtc()',
+    // It's important that we test 0 and -5 as these are encoded differnetly in
+    // postgres where it needs to use BC suffixes!
+    'emptyValue': 'DateTime.utc(0)',
+    'otherValue': 'DateTime.utc(-5)',
     'equality': 'equals',
   },
   {
@@ -79,6 +91,8 @@ final instances = [
     'type': 'Uint8List',
     'initialValue': 'Uint8List.fromList([1, 2, 3])',
     'updatedValue': 'Uint8List.fromList([1, 2, 3, 4])',
+    'emptyValue': 'Uint8List.fromList([])',
+    'otherValue': 'Uint8List.fromList([0])',
     'equality': 'deepEquals',
   },
 ];
@@ -118,6 +132,8 @@ void main() {
 
   final initialValue = {{initialValue}};
   final updatedValue = {{updatedValue}};
+  final emptyValue = {{emptyValue}};
+  final otherValue = {{otherValue}};
 
   r.addTest('.insert()', (db) async {
     await db.items
@@ -129,6 +145,30 @@ void main() {
 
     final item = await db.items.first.fetch();
     check(item).isNotNull().value.{{equality}}(initialValue);
+  });
+
+  r.addTest('.insert(value: empty)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.{{equality}}(emptyValue);
+  });
+
+  r.addTest('.insert(value: other)', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(otherValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.{{equality}}(otherValue);
   });
 
   r.addTest('.insert().returnInserted()', (db) async {


### PR DESCRIPTION
It's not that 'BC' dates are frequently used, or that `DateTime.utc(0)` is important, it's that `DateTime.utc(0)` or `DateTime(0)` can be nice to use instead of `NULL`.