### PR TITLE
Better message when a 'Row' class is not included in the `build.yaml` sources.

### DIFF
--- a/typed_sql/CHANGELOG.md
+++ b/typed_sql/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.1.5
  * Upgraded `package:build` dependency to allow `>=3.0.0 <5.0.0`.
+ * Added check for a `Row` class not included in the `build.yaml` sources.
 
 ## 0.1.4
  * Upgraded dependencies (incl. `package:analyzer`).

--- a/typed_sql/lib/src/codegen/parse_library.dart
+++ b/typed_sql/lib/src/codegen/parse_library.dart
@@ -188,6 +188,12 @@ ParsedSchema _parseSchema(
 
     final typeArg = returnType.typeArguments.first;
     final typeArgElement = typeArg.element;
+    if (typeArgElement == null) {
+      throw InvalidGenerationSource(
+        'Unable to resolve T in `Table<T>` properties, may need to include it in the `build.yaml` sources',
+        element: a,
+      );
+    }
     if (typeArgElement is! ClassElement) {
       throw InvalidGenerationSource(
         'T must be a class in `Table<T>` properties',


### PR DESCRIPTION
This affects schema definitions that span over multiple files, but their `build.yaml` sources list only includes only the main library. In such cases the `T must be a class in `Table<T>` properties` message was not really helpful.