### PR TITLE
Rename: .update() -> updateAll() when it can affect multiple rows

### DIFF
--- a/typed_sql/example/lib/src/model.g.dart
+++ b/typed_sql/example/lib/src/model.g.dart
@@ -207,7 +207,7 @@ extension QueryUserExt on Query<(Expr<User>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<User> update(
+  Update<User> updateAll(
           UpdateSet<User> Function(
             Expr<User> user,
             UpdateSet<User> Function({
@@ -579,7 +579,7 @@ extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Package> update(
+  Update<Package> updateAll(
           UpdateSet<Package> Function(
             Expr<Package> package,
             UpdateSet<Package> Function({
@@ -923,7 +923,7 @@ extension QueryLikeExt on Query<(Expr<Like>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Like> update(
+  Update<Like> updateAll(
           UpdateSet<Like> Function(
             Expr<Like> like,
             UpdateSet<Like> Function({

--- a/typed_sql/lib/src/codegen/build_code.dart
+++ b/typed_sql/lib/src/codegen/build_code.dart
@@ -524,7 +524,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
       ))
       ..methods.add(Method(
         (b) => b
-          ..name = 'update'
+          ..name = 'updateAll'
           ..documentation('''
             Update all rows in the `${table.name}` table matching this [Query].
 

--- a/typed_sql/test/sqlite/model.g.dart
+++ b/typed_sql/test/sqlite/model.g.dart
@@ -207,7 +207,7 @@ extension QueryUserExt on Query<(Expr<User>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<User> update(
+  Update<User> updateAll(
           UpdateSet<User> Function(
             Expr<User> user,
             UpdateSet<User> Function({
@@ -587,7 +587,7 @@ extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Package> update(
+  Update<Package> updateAll(
           UpdateSet<Package> Function(
             Expr<Package> package,
             UpdateSet<Package> Function({
@@ -931,7 +931,7 @@ extension QueryLikeExt on Query<(Expr<Like>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Like> update(
+  Update<Like> updateAll(
           UpdateSet<Like> Function(
             Expr<Like> like,
             UpdateSet<Like> Function({

--- a/typed_sql/test/sqlite/sqlite_test.dart
+++ b/typed_sql/test/sqlite/sqlite_test.dart
@@ -140,7 +140,7 @@ void main() {
     }
     await db.packages
         .where((p) => p.packageName.equalsValue('foo'))
-        .update((p, set) => set(
+        .updateAll((p, set) => set(
               ownerId: toExpr(2),
             ))
         .execute();

--- a/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
+++ b/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
@@ -227,7 +227,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
+++ b/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().deepEquals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.deepEquals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.deepEquals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().equals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().equals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().equals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/real/real_test.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().equals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/real/real_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/crud/text/text_test.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.dart
@@ -93,7 +93,7 @@ void main() {
     check(value).isNotNull().equals(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -102,7 +102,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -111,7 +111,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -120,7 +120,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -134,7 +134,7 @@ void main() {
     check(item).isNotNull().value.equals(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -143,7 +143,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/test/typed_sql/crud/text/text_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.dart
@@ -75,7 +75,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -84,7 +84,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.dart
@@ -82,7 +82,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.dart
@@ -61,7 +61,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -70,7 +70,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();

--- a/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
@@ -183,7 +183,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
+++ b/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
@@ -227,7 +227,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
@@ -227,7 +227,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
+++ b/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/distinct/distinct_model/distinct_model_test.g.dart
+++ b/typed_sql/test/typed_sql/distinct/distinct_model/distinct_model_test.g.dart
@@ -209,7 +209,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
+++ b/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
@@ -209,7 +209,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
+++ b/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
@@ -210,7 +210,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -686,7 +686,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
@@ -199,7 +199,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
+++ b/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
@@ -212,7 +212,7 @@ extension QueryPostExt on Query<(Expr<Post>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Post> update(
+  Update<Post> updateAll(
           UpdateSet<Post> Function(
             Expr<Post> post,
             UpdateSet<Post> Function({
@@ -576,7 +576,7 @@ extension QueryCommentExt on Query<(Expr<Comment>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Comment> update(
+  Update<Comment> updateAll(
           UpdateSet<Comment> Function(
             Expr<Comment> comment,
             UpdateSet<Comment> Function({

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.dart
@@ -107,7 +107,7 @@ void main() {
     // Decrease stock for 'Vegan Dining', return update stock
     final updatedStock = await db.books
         .where((b) => b.title.equals(toExpr('Vegan Dining')))
-        .update((b, set) => set(
+        .updateAll((b, set) => set(
               stock: b.stock - toExpr(1),
             ))
         .returning((b) => (b.stock,))
@@ -560,11 +560,11 @@ void main() {
     // #endregion
   });
 
-  r.addTest('books.where(.stock > 5).update(stock = stock / 2)', (db) async {
+  r.addTest('books.where(.stock > 5).updateAll(stock = stock / 2)', (db) async {
     // #region update-books-where-stock-gt-5
     await db.books
         .where((book) => book.stock > toExpr(5))
-        .update((book, set) => set(
+        .updateAll((book, set) => set(
               stock: (book.stock / toExpr(2)).asInt(),
             ))
         .execute();
@@ -588,12 +588,12 @@ void main() {
     // #endregion
   }, skipMysql: 'RETURNING not supported in MySQL');
 
-  r.addTest('books.where(.stock > 5).update(stock = stock / 2).returning',
+  r.addTest('books.where(.stock > 5).updateAll(stock = stock / 2).returning',
       (db) async {
     // #region update-books-where-returning
     final updatedStock = await db.books
         .where((book) => book.stock > toExpr(5))
-        .update((book, set) => set(
+        .updateAll((book, set) => set(
               stock: (book.stock / toExpr(2)).asInt(),
             ))
         .returning((book) => (book.stock,))

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
@@ -189,7 +189,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -543,7 +543,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/example/company/company_test.g.dart
+++ b/typed_sql/test/typed_sql/example/company/company_test.g.dart
@@ -202,7 +202,7 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Department> update(
+  Update<Department> updateAll(
           UpdateSet<Department> Function(
             Expr<Department> department,
             UpdateSet<Department> Function({
@@ -547,7 +547,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({

--- a/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
+++ b/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
@@ -216,7 +216,7 @@ extension QueryCarExt on Query<(Expr<Car>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Car> update(
+  Update<Car> updateAll(
           UpdateSet<Car> Function(
             Expr<Car> car,
             UpdateSet<Car> Function({

--- a/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
@@ -185,7 +185,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
@@ -199,7 +199,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/test/typed_sql/example/schema/schema_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_test.g.dart
@@ -189,7 +189,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -543,7 +543,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/example/testing/model.g.dart
+++ b/typed_sql/test/typed_sql/example/testing/model.g.dart
@@ -199,7 +199,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
@@ -198,7 +198,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -573,7 +573,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
@@ -198,7 +198,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -573,7 +573,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
@@ -200,7 +200,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -554,7 +554,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
@@ -298,7 +298,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
@@ -209,7 +209,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({

--- a/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
@@ -185,7 +185,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -527,7 +527,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
@@ -209,7 +209,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({

--- a/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
@@ -201,7 +201,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({
@@ -489,7 +489,7 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Department> update(
+  Update<Department> updateAll(
           UpdateSet<Department> Function(
             Expr<Department> department,
             UpdateSet<Department> Function({

--- a/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
@@ -201,7 +201,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({
@@ -489,7 +489,7 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Department> update(
+  Update<Department> updateAll(
           UpdateSet<Department> Function(
             Expr<Department> department,
             UpdateSet<Department> Function({

--- a/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
@@ -208,7 +208,7 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Employee> update(
+  Update<Employee> updateAll(
           UpdateSet<Employee> Function(
             Expr<Employee> employee,
             UpdateSet<Employee> Function({
@@ -549,7 +549,7 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Department> update(
+  Update<Department> updateAll(
           UpdateSet<Department> Function(
             Expr<Department> department,
             UpdateSet<Department> Function({

--- a/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
+++ b/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
@@ -204,7 +204,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
@@ -182,7 +182,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
@@ -227,7 +227,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
@@ -207,7 +207,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -671,7 +671,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
+++ b/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
@@ -200,7 +200,7 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Author> update(
+  Update<Author> updateAll(
           UpdateSet<Author> Function(
             Expr<Author> author,
             UpdateSet<Author> Function({
@@ -554,7 +554,7 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Book> update(
+  Update<Book> updateAll(
           UpdateSet<Book> Function(
             Expr<Book> book,
             UpdateSet<Book> Function({

--- a/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
@@ -180,7 +180,7 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Item> update(
+  Update<Item> updateAll(
           UpdateSet<Item> Function(
             Expr<Item> item,
             UpdateSet<Item> Function({

--- a/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
@@ -199,7 +199,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
@@ -199,7 +199,7 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// > the expressions for updating the rows. You should **never** invoke
   /// > the `set` function more than once, and the result should always
   /// > be returned immediately.
-  Update<Account> update(
+  Update<Account> updateAll(
           UpdateSet<Account> Function(
             Expr<Account> account,
             UpdateSet<Account> Function({

--- a/typed_sql/tool/generate_crud_tests.dart
+++ b/typed_sql/tool/generate_crud_tests.dart
@@ -191,7 +191,7 @@ void main() {
     check(value).isNotNull().{{equality}}(initialValue);
   });
 
-  r.addTest('.update()', (db) async {
+  r.addTest('.updateAll()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -200,7 +200,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .execute();
@@ -209,7 +209,7 @@ void main() {
     check(item).isNotNull().value.{{equality}}(updatedValue);
   });
 
-  r.addTest('.update().returnUpdated()', (db) async {
+  r.addTest('.updateAll().returnUpdated()', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -218,7 +218,7 @@ void main() {
         .execute();
 
     final updatedItems = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returnUpdated()
@@ -232,7 +232,7 @@ void main() {
     check(item).isNotNull().value.{{equality}}(updatedValue);
   }, skipMysql: 'UPDATE RETURNING not supported');
 
-  r.addTest('.update().returning(.value)', (db) async {
+  r.addTest('.updateAll().returning(.value)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -241,7 +241,7 @@ void main() {
         .execute();
 
     final values = await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: toExpr(updatedValue),
             ))
         .returning((item) => (item.value,))

--- a/typed_sql/tool/generate_custom_type_tests.dart
+++ b/typed_sql/tool/generate_custom_type_tests.dart
@@ -147,7 +147,7 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
-  r.addTest('update', (db) async {
+  r.addTest('updateAll', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
@@ -156,7 +156,7 @@ void main() {
         .execute();
 
     await db.items
-        .update((item, set) => set(
+        .updateAll((item, set) => set(
               value: updatedValue.asExpr,
             ))
         .execute();


### PR DESCRIPTION
Interested in your thoughts.

This will make it so that:
 * `QuerySingle<T>` has `.update` (as is right now)
 * `Query<T>` has `.updateAll` (instead of it being named `.update`).

The idea is that this will it slightly more likely that someone will notice something concerning when write:
```dart
await db.myTable.updateAll(...).execute();
```

instead of:
```dart
await db.myTable.byKey(...).update(...).execute();
```

Granted you'll now also have to write `.updateAll` if you have a `.where` clause.


----------

IMO, it's a bit ugly, and `All` is a bit inappropriate, because it really means _update multiple_.

I think perhaps we should stick with `.update()` in both cases, and accept that SQL has sharp edges if you update a table with a `WHERE` clause :D