### PR TITLE
Introduce `.insertValue()`

### DIFF
--- a/typed_sql/CHANGELOG.md
+++ b/typed_sql/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.10-dev
+ * Introduce `.insertValue` which automatically wraps with `toExpr()`, but is
+   unfortunately unable to insert _default value_ for nullable fields that
+   have a default value other than `NULL`.
+
 ## 0.1.9
  * Fix constraint name generation for `FOREIGN KEY` DDLs.
 

--- a/typed_sql/doc/01_schema.md
+++ b/typed_sql/doc/01_schema.md
@@ -183,14 +183,14 @@ value for fields with type:
  * `String`, and,
  * `JsonValue`.
 
-However, since [DateTime] does not have a _const_ constructor one of the
-following annoations must be used to create a [DateTime] field with a
+However, since `DateTime` does not have a _const_ constructor one of the
+following annoations must be used to create a `DateTime` field with a
 _default value_:
  * `@DefaultValue.dateTime(year, [month, day, ...])`,
  * `@DefaultValue.epoch`, or,
  * `@DefaultValue.now`.
 
-With [DefaultValue.now] being a special constructor that uses
+With `DefaultValue.now` being a special constructor that uses
 `CURRENT_TIMESTAMP` in the database to ensure the field
 has a default value of `DateTime.now().toUtc()` when row is inserted.
 
@@ -312,11 +312,12 @@ See [References] documentation for details.
 [DDL]: https://en.wikipedia.org/wiki/Data_definition_language
 
 <!-- GENERATED DOCUMENTATION LINKS -->
-[Custom data types]: ../topics/Custom%20data%20types-topic.html
+[Custom data types]: ../topics/custom_data_types-topic.html
 [CustomDataType]: ../typed_sql/CustomDataType-class.html
 [Database]: ../typed_sql/Database-class.html
 [DatabaseAdapter]: ../typed_sql/DatabaseAdapter-class.html
-[Migrations]: ../topics/Migrations-topic.html
+[DefaultValue]: ../typed_sql/DefaultValue-class.html
+[Migrations]: ../topics/migrations-topic.html
 [References]: ../typed_sql/References-class.html
 [Schema]: ../typed_sql/Schema-class.html
 [SqlDialect]: ../typed_sql/SqlDialect-class.html

--- a/typed_sql/doc/02_inserting_rows.md
+++ b/typed_sql/doc/02_inserting_rows.md
@@ -223,5 +223,5 @@ For more information on subqueries see [Writing queries].
 
 <!-- GENERATED DOCUMENTATION LINKS -->
 [Expr]: ../typed_sql/Expr-class.html
-[Writing queries]: ../topics/Writing%20queries-topic.html
+[Writing queries]: ../topics/writing_queries-topic.html
 [toExpr]: ../typed_sql/toExpr.html

--- a/typed_sql/doc/02_inserting_rows.md
+++ b/typed_sql/doc/02_inserting_rows.md
@@ -64,27 +64,45 @@ await db.authors
     .execute();
 ```
 
-We cannot simply provide `name` or `id` as
+For maximum flexibility we do not simply provide `name` or `id` as
 `String` or `int` respectively. Instead we have to give an `Expr<String>` or
-`Expr<int>`. We can create such expressions using the [toExpr] function.
+`Expr<int>`. We can create such expressions using the [toExpr] function
+(or `.asExpr` extension method).
 
 The `toExpr<T>(T value)` function works for the following types:
  * `bool` (e.g. `toExpr(true)`),
  * `int` (e.g. `toExpr(42)`),
  * `double` (e.g. `toExpr(3.14)`),
  * `String` (e.g. `toExpr('hello world')`),
- * `DateTime` (e.g. `toExpr(DateTime.now())`),
+ * `DateTime` (e.g. `toExpr(DateTime.now())`, will normalize to UTC),
  * `Uint8List` (e.g. `toExpr(Uint8List.from([1, 2, 3]))`), and,
  * `Null` (e.g. `toExpr(null)`).
 
 By wrapping values in `Expr<T>` it possible for `package:typed_sql` to
-distinguish between an omitted value (default value), and intentional decision to
-insert `NULL`. Because `NULL` is always represented as `toExpr(null)`.
+distinguish between an omitted value (default value), and intentional decision
+to insert `NULL`. Because `NULL` is always represented as `toExpr(null)`.
 As we will explore later, this also enables us to insert values directly
 from a subquery.
 
-When wrapping a `DateTime` value, `toExpr` will normalize it to UTC before
-encoding it for the database.
+For convinience, `package:typed_sql` will generate a `.insertValue` method,
+which wraps arguments with [toExpr]. This is strictly less powerful than using
+`.insert` as you cannot insert value from a subquery.
+
+```dart bookstore_test.dart#authors-insertValue-with-id
+await db.authors
+    .insertValue(
+      authorId: 42,
+      name: 'Roger Rabbit',
+    )
+    .execute();
+```
+
+> [!CAUTION]
+> If a field is _nullable_ in the database, then providing `null` to
+> `insertValue` will insert `NULL`, even if the field has a _default value_.
+>
+> It is possible to omit a field that has a _default value_ by providing `null`,
+> but for nullable fields, this does **not** insert the _default value_.
 
 
 ## Insert with `RETURNING` clause

--- a/typed_sql/doc/03_writing_queries.md
+++ b/typed_sql/doc/03_writing_queries.md
@@ -869,5 +869,5 @@ The above documentation does not outline how `.join` and `.groupBy` works, for
 details on how to use these see [Joins] and [Aggregate functions].
 
 <!-- GENERATED DOCUMENTATION LINKS -->
-[Aggregate functions]: ../topics/Aggregate%20functions-topic.html
-[Joins]: ../topics/Joins-topic.html
+[Aggregate functions]: ../topics/aggregate_functions-topic.html
+[Joins]: ../topics/joins-topic.html

--- a/typed_sql/doc/04_update_and_delete.md
+++ b/typed_sql/doc/04_update_and_delete.md
@@ -255,4 +255,4 @@ But if you use it on a `QuerySingle<(Expr<T>,)>`, you just get a nullable row.
 <!-- GENERATED DOCUMENTATION LINKS -->
 [Query]: ../typed_sql/Query-class.html
 [QuerySingle]: ../typed_sql/QuerySingle-class.html
-[Writing queries]: ../topics/Writing%20queries-topic.html
+[Writing queries]: ../topics/writing_queries-topic.html

--- a/typed_sql/doc/05_foreign_keys.md
+++ b/typed_sql/doc/05_foreign_keys.md
@@ -285,4 +285,4 @@ attached.
 > consistent of a single field.
 
 <!-- GENERATED DOCUMENTATION LINKS -->
-[Aggregate functions]: ../topics/Aggregate%20functions-topic.html
+[Aggregate functions]: ../topics/aggregate_functions-topic.html

--- a/typed_sql/doc/09_exceptions.md
+++ b/typed_sql/doc/09_exceptions.md
@@ -65,6 +65,6 @@ simply misconfigured.
 [OperationException]: ../typed_sql/OperationException-class.html
 [TransactionAbortedException]: ../typed_sql/TransactionAbortedException-class.html
 [TransactionAbortedException.reason]: ../typed_sql/TransactionAbortedException/reason.html
-[Transactions]: ../topics/Transactions-topic.html
+[Transactions]: ../topics/transactions-topic.html
 [TypeCastException]: ../typed_sql/TypeCastException-class.html
 [UnspecifiedOperationException]: ../typed_sql/UnspecifiedOperationException-class.html

--- a/typed_sql/example/lib/src/model.g.dart
+++ b/typed_sql/example/lib/src/model.g.dart
@@ -124,6 +124,19 @@ extension TableUserExt on Table<User> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [userId, name, email]);
 
+  /// Insert row into the `users` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<User> insertValue({
+    int? userId,
+    required String name,
+    required String email,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [userId?.asExpr, name.asExpr, email.asExpr],
+  );
+
   /// Delete a single row from the `users` table, specified by
   /// _primary key_.
   ///
@@ -460,6 +473,25 @@ extension TablePackageExt on Table<Package> {
     values: [packageName, likes, ownerId, publisher],
   );
 
+  /// Insert row into the `packages` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Package> insertValue({
+    required String packageName,
+    int? likes,
+    required int ownerId,
+    String? publisher,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      packageName.asExpr,
+      likes?.asExpr,
+      ownerId.asExpr,
+      publisher.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `packages` table, specified by
   /// _primary key_.
   ///
@@ -774,6 +806,18 @@ extension TableLikeExt on Table<Like> {
     required Expr<String> packageName,
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [userId, packageName]);
+
+  /// Insert row into the `likes` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Like> insertValue({
+    required int userId,
+    required String packageName,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [userId.asExpr, packageName.asExpr],
+  );
 
   /// Delete a single row from the `likes` table, specified by
   /// _primary key_.

--- a/typed_sql/lib/src/codegen/build_code.dart
+++ b/typed_sql/lib/src/codegen/build_code.dart
@@ -314,7 +314,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
         'Unsupported type "${field.typeName}"',
       ),
     };
-    if (field.backingType == field.typeName) {
+    if (!field.isCustomType) {
       return readBackingType;
     }
     return '''
@@ -486,6 +486,63 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
               ],
             )
           '''),
+        ),
+      )
+      ..methods.add(
+        Method(
+          (b) => b
+            ..name = 'insertValue'
+            ..documentation('''
+              Insert row into the `${table.name}` table.
+
+              ${rowClass.fields.whereDefaultAndNullable.isEmpty ? '' : '''\n
+              > [!WARNING]
+              > It is not possible to insert the _default value_ for fields that
+              > are nullable. Providing `null` will insert `NULL` for
+              > ${rowClass.fields.whereDefaultAndNullable.map((f) => '`${f.name}`').join(', ')}.
+              '''}
+
+              Returns a [InsertSingle] statement on which `.execute` must be
+              called for the row to be inserted.
+            ''')
+            ..optionalParameters.addAll(
+              rowClass.fields.map((field) {
+                // Field is optional if it has a default value xor is nullable,
+                // but if it's both nullable and has a default value, then we
+                // will make it required! Because the default value of null will
+                // be read as NULL in the database and it won't get the database
+                // default value.
+                // NOTE: We do not set the default value as _default value_ in
+                //       dart, because this does not work for auto-increment or
+                //       for NOW() and similar annotations.
+                final isOptional = field.hasDefault ^ field.isNullable;
+                final nullable = field.hasDefault || field.isNullable
+                    ? '?'
+                    : '';
+
+                return Parameter(
+                  (b) => b
+                    ..name = field.name
+                    ..named = true
+                    ..required = !isOptional
+                    ..type = refer('${field.typeName}$nullable'),
+                );
+              }),
+            )
+            ..returns = refer('InsertSingle<$rowClassName>')
+            ..lambda = true
+            ..body = Code('''
+              \$ForGeneratedCode.insertInto(
+                table: this,
+                values: [${rowClass.fields.map((field) {
+              // Use .asExpr to support custom data types
+              // Use ?.asExpr if there is a default value and the field is not
+              // nullable.
+              final canOmit = field.hasDefault && !field.isNullable;
+              return '${field.name}${canOmit ? '?' : ''}.asExpr';
+            }).join(', ')},],
+              )
+            '''),
         ),
       )
       ..methods.add(
@@ -1265,6 +1322,21 @@ extension on ParsedRecord {
 
 extension on ParsedField {
   String get type => isNullable ? '$typeName?' : typeName;
+
+  bool get hasDefault => defaultValue != null || autoIncrement;
+
+  bool get isCustomType => backingType != typeName;
+}
+
+extension on List<ParsedField> {
+  /// Get a list of fields that both have a default value and are nullable.
+  ///
+  /// These fields are somewhat problematic to accept in `insertValue`, because
+  /// we map `null` to `NULL`, so there is no way to insert the and get the
+  /// default value. This kind of matters if the _default value_ is
+  /// auto-increment or `NOW()`. Hence, we should warn users.
+  List<ParsedField> get whereDefaultAndNullable =>
+      where((f) => f.hasDefault && f.isNullable).toList();
 }
 
 String backingExprType(String backingType) {
@@ -1284,7 +1356,7 @@ String backingExprType(String backingType) {
 
 String fieldType(ParsedField field) {
   var backingTypeName = backingExprType(field.backingType);
-  if (field.backingType == field.typeName) {
+  if (!field.isCustomType) {
     return backingTypeName;
   }
   return '${field.typeName}Ext._exprType';

--- a/typed_sql/lib/src/codegen/build_code.dart
+++ b/typed_sql/lib/src/codegen/build_code.dart
@@ -507,16 +507,43 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
             ''')
             ..optionalParameters.addAll(
               rowClass.fields.map((field) {
-                // Field is optional if it has a default value xor is nullable,
-                // but if it's both nullable and has a default value, then we
-                // will make it required! Because the default value of null will
-                // be read as NULL in the database and it won't get the database
-                // default value.
+                // Depending on whether a field has a default value and/or is
+                // nullable we have the following cases:
+                //
+                //  1. `!hasDefault && !isNullable`:
+                //     The user must give us a value!
+                //     The parameter is _required_ and non-nullable.
+                //
+                //  2. `hasDefault && !isNullable`:
+                //     The user may give us a value, or we can omit the field
+                //     and the database will insert the _default value_.
+                //     The parameter is optional and nullable, null means omit
+                //     the field when inserting the row.
+                //
+                //  3. `!hasDefault && isNullable`:
+                //     The user may give us a value, or we can insert `NULL` as
+                //     the default value -- this also what .insert() does!
+                //     The parameter is optional and nullable, null means set
+                //     the field `NULL` when inserting the row.
+                //
+                //  4. `hasDefault && isNullable`:
+                //     The user may give us a value, or omit the field to get
+                //     _default value_, or the user may give `null` meaning
+                //     `NULL`. We cannot represent all 3 options!
+                //     We always intepret `null` as `NULL`, thus, the user
+                //     cannot omit the field and get the _default value_.
+                //     The user can use `.insert()` instead of `.insertValue()`.
+                //     This could be surprising which is why we have:
+                //      * A warning in the documentation, and,
+                //      * Decided that the parameter is _required_ and nullable.
+                //     The parameter is _required_ and _nullable_, so that
+                //     inserting `null` is explicit, not implicit!
+                //
                 // NOTE: We do not set the default value as _default value_ in
                 //       dart, because this does not work for auto-increment or
                 //       for NOW() and similar annotations.
                 final isOptional = field.hasDefault ^ field.isNullable;
-                final nullable = field.hasDefault || field.isNullable
+                final nullablePostfix = field.hasDefault || field.isNullable
                     ? '?'
                     : '';
 
@@ -525,7 +552,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
                     ..name = field.name
                     ..named = true
                     ..required = !isOptional
-                    ..type = refer('${field.typeName}$nullable'),
+                    ..type = refer('${field.typeName}$nullablePostfix'),
                 );
               }),
             )

--- a/typed_sql/lib/src/codegen/code_builder_ext.dart
+++ b/typed_sql/lib/src/codegen/code_builder_ext.dart
@@ -27,22 +27,31 @@ extension ExtensionBuilderExt on ExtensionBuilder {
   }
 }
 
-Iterable<String> _documentationCommentLines(String content) =>
-    _trimLines(content)
-        .split('\n')
-        .skipWhile((l) => l.trim().isEmpty)
-        .toList()
-        .reversed
-        .skipWhile((l) => l.trim().isEmpty)
-        .toList()
-        .reversed
-        .map((l) {
-          l = l.trimRight();
-          if (l.isEmpty) {
-            return '///';
-          }
-          return '/// $l';
-        });
+Iterable<String> _documentationCommentLines(String content) sync* {
+  final lines = _trimLines(content).split('\n');
+
+  // Find the boundaries to naturally skip leading and trailing empty lines
+  final startIndex = lines.indexWhere((l) => l.trim().isNotEmpty);
+  if (startIndex == -1) {
+    return;
+  }
+  final endIndex = lines.lastIndexWhere((l) => l.trim().isNotEmpty);
+
+  var previousWasEmpty = false;
+
+  for (var i = startIndex; i <= endIndex; i++) {
+    final line = lines[i].trimRight();
+    final isEmpty = line.isEmpty;
+
+    // Collapse multiple empty lines into one
+    if (isEmpty && previousWasEmpty) {
+      continue;
+    }
+
+    previousWasEmpty = isEmpty;
+    yield isEmpty ? '///' : '/// $line';
+  }
+}
 
 /// Trim whitespace at the start of lines in [content]
 String _trimLines(String content) {

--- a/typed_sql/pubspec.yaml
+++ b/typed_sql/pubspec.yaml
@@ -1,5 +1,5 @@
 name: typed_sql
-version: 0.1.9
+version: 0.1.10-dev
 description: Package for doing SQL with some type safety.
 homepage: https://github.com/google/dart-neats/tree/master/typed_sql
 repository: https://github.com/google/dart-neats.git

--- a/typed_sql/test/sqlite/model.g.dart
+++ b/typed_sql/test/sqlite/model.g.dart
@@ -124,6 +124,19 @@ extension TableUserExt on Table<User> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [userId, name, email]);
 
+  /// Insert row into the `users` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<User> insertValue({
+    int? userId,
+    required String name,
+    required String email,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [userId?.asExpr, name.asExpr, email.asExpr],
+  );
+
   /// Delete a single row from the `users` table, specified by
   /// _primary key_.
   ///
@@ -468,6 +481,25 @@ extension TablePackageExt on Table<Package> {
     values: [packageName, likes, ownerId, publisher],
   );
 
+  /// Insert row into the `packages` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Package> insertValue({
+    required String packageName,
+    int? likes,
+    required int ownerId,
+    String? publisher,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      packageName.asExpr,
+      likes?.asExpr,
+      ownerId.asExpr,
+      publisher.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `packages` table, specified by
   /// _primary key_.
   ///
@@ -782,6 +814,18 @@ extension TableLikeExt on Table<Like> {
     required Expr<String> packageName,
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [userId, packageName]);
+
+  /// Insert row into the `likes` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Like> insertValue({
+    required int userId,
+    required String packageName,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [userId.asExpr, packageName.asExpr],
+  );
 
   /// Delete a single row from the `likes` table, specified by
   /// _primary key_.

--- a/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
+++ b/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
@@ -144,6 +144,27 @@ extension TableItemExt on Table<Item> {
     values: [id, text, real, timestamp, integer],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String text,
+    required double real,
+    required DateTime timestamp,
+    int? integer,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      id?.asExpr,
+      text.asExpr,
+      real.asExpr,
+      timestamp.asExpr,
+      integer.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
+++ b/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.deepEquals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.deepEquals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.deepEquals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.deepEquals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().deepEquals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<Uint8List> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required Uint8List value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.equals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().equals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<bool> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required bool value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.equals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().equals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<DateTime> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required DateTime value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.equals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().equals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<int> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required int value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/json/json_test.dart
+++ b/typed_sql/test/typed_sql/crud/json/json_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.deepEquals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.deepEquals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.deepEquals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.deepEquals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.deepEquals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().deepEquals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/json/json_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/json/json_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<JsonValue> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required JsonValue value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/real/real_test.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.equals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().equals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/real/real_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<double> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required double value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/crud/text/text_test.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.dart
@@ -47,11 +47,35 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -71,6 +95,18 @@ void main() {
     check(item).isNotNull().value.equals(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -82,11 +118,33 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().equals(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/test/typed_sql/crud/text/text_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomTypeAlias> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomTypeAlias value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.dart
@@ -69,6 +69,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
@@ -101,6 +101,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<JsonValue> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required JsonValue value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.dart
@@ -61,6 +61,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
     required Expr<MyCustomType> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required MyCustomType value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.dart
+++ b/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.dart
@@ -42,7 +42,16 @@ void main() {
     check(item).isNotNull().name.equals('Bob');
   });
 
-  r.addTest('override defaults', (db) async {
+  r.addTest('.insertValue() DEFAULT VALUES', (db) async {
+    // Inserting a row with all default values.
+    // This requires special syntax in sqlite and postgres.
+    await db.items.insertValue().execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().name.equals('Bob');
+  });
+
+  r.addTest('.insert() override defaults', (db) async {
     final bday = DateTime.utc(2000, 1, 1);
     final now = DateTime.utc(2023, 10, 27, 12, 0, 0);
     final exp = DateTime.utc(2025, 1, 1);
@@ -53,6 +62,32 @@ void main() {
           birthday: toExpr(bday),
           createdAt: toExpr(now),
           expires: toExpr(exp),
+        )
+        .execute();
+
+    final item = await db.items
+        .where(
+          (i) => i.name.equalsValue('Charlie'),
+        )
+        .first
+        .fetch();
+
+    check(item).isNotNull().birthday.equals(bday);
+    check(item).isNotNull().createdAt.equals(now);
+    check(item).isNotNull().expires.equals(exp);
+  });
+
+  r.addTest('.insertValue() override defaults', (db) async {
+    final bday = DateTime.utc(2000, 1, 1);
+    final now = DateTime.utc(2023, 10, 27, 12, 0, 0);
+    final exp = DateTime.utc(2025, 1, 1);
+
+    await db.items
+        .insertValue(
+          name: 'Charlie',
+          birthday: bday,
+          createdAt: now,
+          expires: exp,
         )
         .execute();
 

--- a/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
+++ b/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
@@ -144,6 +144,27 @@ extension TableItemExt on Table<Item> {
     values: [id, name, birthday, createdAt, expires],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    String? name,
+    DateTime? birthday,
+    DateTime? createdAt,
+    DateTime? expires,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      id?.asExpr,
+      name?.asExpr,
+      birthday?.asExpr,
+      createdAt?.asExpr,
+      expires?.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
@@ -144,6 +144,27 @@ extension TableItemExt on Table<Item> {
     values: [id, name, birthday, createdAt, expires],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String name,
+    DateTime? birthday,
+    DateTime? createdAt,
+    DateTime? expires,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      id?.asExpr,
+      name.asExpr,
+      birthday?.asExpr,
+      createdAt?.asExpr,
+      expires?.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<double>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, double? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.dart
+++ b/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.dart
@@ -1,0 +1,172 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+
+import '../../testrunner.dart';
+
+part 'default_nullable_int_test.g.dart';
+
+abstract final class TestDatabase extends Schema {
+  Table<Item> get items;
+}
+
+@PrimaryKey(['id'])
+abstract final class Item extends Row {
+  @AutoIncrement()
+  int get id;
+
+  @DefaultValue(42)
+  int? get value;
+}
+
+void main() {
+  final r = TestRunner<TestDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('.insert() without default', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(3),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(3);
+  });
+
+  r.addTest('.insert() with default', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(42);
+  });
+
+  r.addTest('.insert() with null', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(null),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.update() after .insert with default value', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(42);
+
+    await db.items
+        .byKey(1)
+        .update(
+          (item, set) => set(
+            value: toExpr(3),
+          ),
+        )
+        .execute();
+
+    final updateItem = await db.items.first.fetch();
+    check(updateItem).isNotNull().value.equals(3);
+  });
+
+  r.addTest('.update() after .insert with null', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(null),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+
+    await db.items
+        .byKey(1)
+        .update(
+          (item, set) => set(
+            value: toExpr(3),
+          ),
+        )
+        .execute();
+
+    final updateItem = await db.items.first.fetch();
+    check(updateItem).isNotNull().value.equals(3);
+  });
+
+  r.addTest('.insertValue() without default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: 3,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(3);
+  });
+
+  r.addTest('.insertValue() with null', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null, // required, cannot default value null here
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.update() after .insertValue with null', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null, // required, cannot insert default value here
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+
+    await db.items
+        .byKey(1)
+        .update(
+          (item, set) => set(
+            value: toExpr(3),
+          ),
+        )
+        .execute();
+
+    final updateItem = await db.items.first.fetch();
+    check(updateItem).isNotNull().value.equals(3);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
@@ -1,0 +1,287 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'default_nullable_int_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [TestDatabase].
+extension TestDatabaseSchema on Database<TestDatabase> {
+  static final _$tables = [_$Item._$table];
+
+  Table<Item> get items => $ForGeneratedCode.declareTable(this, _$Item._$table);
+
+  /// Create tables defined in [TestDatabase].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [TestDatabase]. In production it's often better to
+  /// use [createTestDatabaseTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [TestDatabase].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [TestDatabase]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createTestDatabaseTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: TestDatabaseSchema._$tables);
+
+final class _$Item extends Item {
+  _$Item._(this.id, this.value);
+
+  @override
+  final int id;
+
+  @override
+  final int? value;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'items',
+    columns: <String>['id', 'value'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: false,
+        defaultValue: (kind: 'raw', value: 42),
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Item._$fromDatabase,
+  );
+
+  static Item? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final value = row.readInt();
+    if (id == null && value == null) {
+      return null;
+    }
+    return _$Item._(id!, value);
+  }
+
+  @override
+  String toString() => 'Item(id: "$id", value: "$value")';
+}
+
+/// Extension methods for table defined in [Item].
+extension TableItemExt on Table<Item> {
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insert({Expr<int>? id, Expr<int?>? value}) =>
+      $ForGeneratedCode.insertInto(table: this, values: [id, value]);
+
+  /// Insert row into the `items` table.
+  ///
+  /// > [!WARNING]
+  /// > It is not possible to insert the _default value_ for fields that
+  /// > are nullable. Providing `null` will insert `NULL` for
+  /// > `value`.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required int? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [toExpr(id), toExpr(value)],
+      );
+
+  /// Delete a single row from the `items` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Item> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
+}
+
+/// Extension methods for building queries against the `items` table.
+extension QueryItemExt on Query<(Expr<Item>,)> {
+  /// Lookup a single row in `items` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Item>,)> byKey(int id) =>
+      where((item) => item.id.equalsValue(id)).first;
+
+  /// Update all rows in the `items` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Item> update(
+    UpdateSet<Item> Function(
+      Expr<Item> item,
+      UpdateSet<Item> Function({Expr<int> id, Expr<int?> value}) set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Item>(
+    this,
+    _$Item._$table,
+    (item) => updateBuilder(
+      item,
+      ({Expr<int>? id, Expr<int?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, value]),
+    ),
+  );
+
+  /// Delete all rows in the `items` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Item> delete() => $ForGeneratedCode.delete(this, _$Item._$table);
+}
+
+/// Extension methods for building point queries against the `items` table.
+extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
+  /// Update the row (if any) in the `items` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Item> update(
+    UpdateSet<Item> Function(
+      Expr<Item> item,
+      UpdateSet<Item> Function({Expr<int> id, Expr<int?> value}) set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Item>(
+    this,
+    _$Item._$table,
+    (item) => updateBuilder(
+      item,
+      ({Expr<int>? id, Expr<int?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, value]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `items` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Item> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Item._$table);
+}
+
+/// Extension methods for expressions on a row in the `items` table.
+extension ExpressionItemExt on Expr<Item> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<int?> get value =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.integer);
+}
+
+extension ExpressionNullableItemExt on Expr<Item?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<int?> get value =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.integer);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// Extension methods for assertions on [Item] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ItemChecks on Subject<Item> {
+  /// Create assertions on [Item.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [Item.value].
+  Subject<int?> get value => has((m) => m.value, 'value');
+}

--- a/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
@@ -110,7 +110,7 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insertValue({int? id, required int? value}) =>
       $ForGeneratedCode.insertInto(
         table: this,
-        values: [toExpr(id), toExpr(value)],
+        values: [id?.asExpr, value.asExpr],
       );
 
   /// Delete a single row from the `items` table, specified by

--- a/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
+++ b/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<double>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, double? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<bool>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, bool? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<int>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, int? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json/default_json_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json/default_json_test.g.dart
@@ -101,6 +101,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<JsonValue>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, JsonValue? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value?.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json_nested_structures/default_json_nested_structures_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json_nested_structures/default_json_nested_structures_test.g.dart
@@ -117,6 +117,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<JsonValue>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, JsonValue? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value?.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json_single_quote/default_json_single_quote_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json_single_quote/default_json_single_quote_test.g.dart
@@ -101,6 +101,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<JsonValue>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, JsonValue? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value?.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.dart
+++ b/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.dart
@@ -1,0 +1,81 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+//
+// See tool/generate_default_tests.dart
+
+import 'package:typed_sql/typed_sql.dart';
+
+import '../../../testrunner.dart';
+
+part 'default_nullable_text_test.g.dart';
+
+abstract final class TestDatabase extends Schema {
+  Table<Item> get items;
+}
+
+const _defaultValue = 'hello';
+const _nonDefaultValue = 'hello world';
+
+@PrimaryKey(['id'])
+abstract final class Item extends Row {
+  @AutoIncrement()
+  int get id;
+
+  @DefaultValue(_defaultValue)
+  String? get value;
+}
+
+void main() {
+  final r = TestRunner<TestDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('.insert() without default', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+          value: toExpr(_nonDefaultValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(_nonDefaultValue);
+  });
+
+  r.addTest('.insert() with default', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(_defaultValue);
+  });
+
+  r.addTest('.update() default value', (db) async {
+    await db.items
+        .insert(
+          id: toExpr(1),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(_defaultValue);
+
+    await db.items
+        .byKey(1)
+        .update(
+          (item, set) => set(
+            value: toExpr(_nonDefaultValue),
+          ),
+        )
+        .execute();
+
+    final updateItem = await db.items.first.fetch();
+    check(updateItem).isNotNull().value.equals(_nonDefaultValue);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
@@ -110,7 +110,7 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insertValue({int? id, required String? value}) =>
       $ForGeneratedCode.insertInto(
         table: this,
-        values: [toExpr(id), toExpr(value)],
+        values: [id?.asExpr, value.asExpr],
       );
 
   /// Delete a single row from the `items` table, specified by

--- a/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
@@ -1,0 +1,287 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'default_nullable_text_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [TestDatabase].
+extension TestDatabaseSchema on Database<TestDatabase> {
+  static final _$tables = [_$Item._$table];
+
+  Table<Item> get items => $ForGeneratedCode.declareTable(this, _$Item._$table);
+
+  /// Create tables defined in [TestDatabase].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [TestDatabase]. In production it's often better to
+  /// use [createTestDatabaseTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [TestDatabase].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [TestDatabase]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createTestDatabaseTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: TestDatabaseSchema._$tables);
+
+final class _$Item extends Item {
+  _$Item._(this.id, this.value);
+
+  @override
+  final int id;
+
+  @override
+  final String? value;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'items',
+    columns: <String>['id', 'value'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: false,
+        defaultValue: (kind: 'raw', value: 'hello'),
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Item._$fromDatabase,
+  );
+
+  static Item? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final value = row.readString();
+    if (id == null && value == null) {
+      return null;
+    }
+    return _$Item._(id!, value);
+  }
+
+  @override
+  String toString() => 'Item(id: "$id", value: "$value")';
+}
+
+/// Extension methods for table defined in [Item].
+extension TableItemExt on Table<Item> {
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insert({Expr<int>? id, Expr<String?>? value}) =>
+      $ForGeneratedCode.insertInto(table: this, values: [id, value]);
+
+  /// Insert row into the `items` table.
+  ///
+  /// > [!WARNING]
+  /// > It is not possible to insert the _default value_ for fields that
+  /// > are nullable. Providing `null` will insert `NULL` for
+  /// > `value`.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [toExpr(id), toExpr(value)],
+      );
+
+  /// Delete a single row from the `items` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Item> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
+}
+
+/// Extension methods for building queries against the `items` table.
+extension QueryItemExt on Query<(Expr<Item>,)> {
+  /// Lookup a single row in `items` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Item>,)> byKey(int id) =>
+      where((item) => item.id.equalsValue(id)).first;
+
+  /// Update all rows in the `items` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Item> update(
+    UpdateSet<Item> Function(
+      Expr<Item> item,
+      UpdateSet<Item> Function({Expr<int> id, Expr<String?> value}) set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Item>(
+    this,
+    _$Item._$table,
+    (item) => updateBuilder(
+      item,
+      ({Expr<int>? id, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, value]),
+    ),
+  );
+
+  /// Delete all rows in the `items` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Item> delete() => $ForGeneratedCode.delete(this, _$Item._$table);
+}
+
+/// Extension methods for building point queries against the `items` table.
+extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
+  /// Update the row (if any) in the `items` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Item> update(
+    UpdateSet<Item> Function(
+      Expr<Item> item,
+      UpdateSet<Item> Function({Expr<int> id, Expr<String?> value}) set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Item>(
+    this,
+    _$Item._$table,
+    (item) => updateBuilder(
+      item,
+      ({Expr<int>? id, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, value]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `items` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Item> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Item._$table);
+}
+
+/// Extension methods for expressions on a row in the `items` table.
+extension ExpressionItemExt on Expr<Item> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get value =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+}
+
+extension ExpressionNullableItemExt on Expr<Item?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get value =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// Extension methods for assertions on [Item] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ItemChecks on Subject<Item> {
+  /// Create assertions on [Item.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [Item.value].
+  Subject<String?> get value => has((m) => m.value, 'value');
+}

--- a/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<double>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, double? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<String>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, String? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<double>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, double? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value?.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/distinct/distinct_model/distinct_model_test.g.dart
+++ b/typed_sql/test/typed_sql/distinct/distinct_model/distinct_model_test.g.dart
@@ -144,6 +144,21 @@ extension TableItemExt on Table<Item> {
     values: [id, text, integer, real, json],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String text,
+    required int integer,
+    required double real,
+    required JsonValue json,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, text.asExpr, integer.asExpr, real.asExpr, json.asExpr],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
+++ b/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
@@ -144,6 +144,21 @@ extension TableItemExt on Table<Item> {
     values: [id, text, integer, real, json],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    String? text,
+    int? integer,
+    double? real,
+    JsonValue? json,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, text.asExpr, integer.asExpr, real.asExpr, json.asExpr],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
+++ b/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
@@ -131,6 +131,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, name, favoriteBookId],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String name,
+    int? favoriteBookId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, name.asExpr, favoriteBookId.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -579,6 +592,27 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, editorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required int authorId,
+    int? editorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      bookId?.asExpr,
+      title.asExpr,
+      authorId.asExpr,
+      editorId.asExpr,
+      stock.asExpr,
+    ],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
@@ -121,6 +121,19 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber, balance],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
+++ b/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
@@ -123,6 +123,19 @@ extension TablePostExt on Table<Post> {
     values: [author, slug, content],
   );
 
+  /// Insert row into the `posts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Post> insertValue({
+    required String author,
+    required String slug,
+    required String content,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [author.asExpr, slug.asExpr, content.asExpr],
+  );
+
   /// Delete a single row from the `posts` table, specified by
   /// _primary key_.
   ///
@@ -455,6 +468,20 @@ extension TableCommentExt on Table<Comment> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [commentId, author, postSlug, comment],
+  );
+
+  /// Insert row into the `comments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Comment> insertValue({
+    required int commentId,
+    required String author,
+    required String postSlug,
+    required String comment,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [commentId.asExpr, author.asExpr, postSlug.asExpr, comment.asExpr],
   );
 
   /// Delete a single row from the `comments` table, specified by

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.dart
@@ -243,6 +243,17 @@ void main() {
     // #endregion
   });
 
+  r.addTest('authors.insertValue w. authorId', (db) async {
+    // #region authors-insertValue-with-id
+    await db.authors
+        .insertValue(
+          authorId: 42,
+          name: 'Roger Rabbit',
+        )
+        .execute();
+    // #endregion
+  });
+
   r.addTest('authors.insert().returnInserted', (db) async {
     // #region authors-insert-returnInserted
     final author = await db.authors

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
@@ -107,6 +107,16 @@ extension TableAuthorExt on Table<Author> {
     required Expr<String> name,
   }) => $ForGeneratedCode.insertInto(table: this, values: [authorId, name]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({int? authorId, required String name}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [toExpr(authorId), toExpr(name)],
+      );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -420,6 +430,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    String? title,
+    required int authorId,
+    int? stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [toExpr(bookId), toExpr(title), toExpr(authorId), toExpr(stock)],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
@@ -114,7 +114,7 @@ extension TableAuthorExt on Table<Author> {
   InsertSingle<Author> insertValue({int? authorId, required String name}) =>
       $ForGeneratedCode.insertInto(
         table: this,
-        values: [toExpr(authorId), toExpr(name)],
+        values: [authorId?.asExpr, name.asExpr],
       );
 
   /// Delete a single row from the `authors` table, specified by
@@ -443,7 +443,7 @@ extension TableBookExt on Table<Book> {
     int? stock,
   }) => $ForGeneratedCode.insertInto(
     table: this,
-    values: [toExpr(bookId), toExpr(title), toExpr(authorId), toExpr(stock)],
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock?.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/example/company/company_test.g.dart
+++ b/typed_sql/test/typed_sql/example/company/company_test.g.dart
@@ -123,6 +123,19 @@ extension TableDepartmentExt on Table<Department> {
     values: [departmentId, name, location],
   );
 
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({
+    int? departmentId,
+    required String name,
+    required String location,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [departmentId?.asExpr, name.asExpr, location.asExpr],
+  );
+
   /// Delete a single row from the `departments` table, specified by
   /// _primary key_.
   ///
@@ -442,6 +455,19 @@ extension TableEmployeeExt on Table<Employee> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [employeeId, name, departmentId],
+  );
+
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? employeeId,
+    required String name,
+    int? departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId?.asExpr, name.asExpr, departmentId.asExpr],
   );
 
   /// Delete a single row from the `employees` table, specified by

--- a/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
+++ b/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
@@ -135,6 +135,20 @@ extension TableCarExt on Table<Car> {
     values: [id, model, licensePlate, color],
   );
 
+  /// Insert row into the `cars` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Car> insertValue({
+    int? id,
+    required String model,
+    required String licensePlate,
+    required Color color,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, model.asExpr, licensePlate.asExpr, color.asExpr],
+  );
+
   /// Delete a single row from the `cars` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
@@ -109,6 +109,18 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
@@ -121,6 +121,19 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber, balance],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/example/schema/schema_default_value/schema_default_value_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_default_value/schema_default_value_test.g.dart
@@ -107,6 +107,16 @@ extension TableAuthorExt on Table<Author> {
     required Expr<String> name,
   }) => $ForGeneratedCode.insertInto(table: this, values: [authorId, name]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({int? authorId, required String name}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [authorId?.asExpr, name.asExpr],
+      );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -420,6 +430,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    String? title,
+    required int authorId,
+    int? stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock?.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/example/schema/schema_references/schema_references_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_references/schema_references_test.g.dart
@@ -107,6 +107,16 @@ extension TableAuthorExt on Table<Author> {
     required Expr<String> name,
   }) => $ForGeneratedCode.insertInto(table: this, values: [authorId, name]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({int? authorId, required String name}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [authorId?.asExpr, name.asExpr],
+      );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -420,6 +430,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    String? title,
+    required int authorId,
+    int? stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock?.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/example/testing/model.g.dart
+++ b/typed_sql/test/typed_sql/example/testing/model.g.dart
@@ -121,6 +121,19 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber, balance],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
@@ -108,6 +108,18 @@ extension TableAuthorExt on Table<Author> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [firstName, lastName]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    required String firstName,
+    required String lastName,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [firstName.asExpr, lastName.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -474,6 +486,27 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorFirstName, authorLastName, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required String authorFirstName,
+    required String authorLastName,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      bookId?.asExpr,
+      title.asExpr,
+      authorFirstName.asExpr,
+      authorLastName.asExpr,
+      stock.asExpr,
+    ],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
@@ -108,6 +108,18 @@ extension TableAuthorExt on Table<Author> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [firstName, lastName]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    required String firstName,
+    required String lastName,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [firstName.asExpr, lastName.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -474,6 +486,27 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorFirstName, authorLastName, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    String? authorFirstName,
+    String? authorLastName,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      bookId?.asExpr,
+      title.asExpr,
+      authorFirstName.asExpr,
+      authorLastName.asExpr,
+      stock.asExpr,
+    ],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    int? authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    int? authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    int? authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    int? authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required int authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/group_by/group_by_bugs/group_by_bugs_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_bugs/group_by_bugs_test.g.dart
@@ -128,6 +128,20 @@ extension TableItemExt on Table<Item> {
     values: [id, category, data, score],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String category,
+    required JsonValue data,
+    required int score,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, category.asExpr, data.asExpr, score.asExpr],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
@@ -270,6 +270,39 @@ extension TableItemExt on Table<Item> {
     ],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String text,
+    required double real,
+    required int integer,
+    required DateTime timestamp,
+    required JsonValue json,
+    String? optText,
+    double? optReal,
+    int? optInteger,
+    DateTime? optTimestamp,
+    JsonValue? optJson,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      id?.asExpr,
+      text.asExpr,
+      real.asExpr,
+      integer.asExpr,
+      timestamp.asExpr,
+      json.asExpr,
+      optText.asExpr,
+      optReal.asExpr,
+      optInteger.asExpr,
+      optTimestamp.asExpr,
+      optJson.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_expression/group_by_expression_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_expression/group_by_expression_test.g.dart
@@ -115,6 +115,19 @@ extension TableEmployeeExt on Table<Employee> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, surname, salary]);
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? id,
+    required String surname,
+    required int salary,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, surname.asExpr, salary.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_having/group_by_having_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_having/group_by_having_test.g.dart
@@ -115,6 +115,19 @@ extension TableEmployeeExt on Table<Employee> {
   }) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, surname, salary]);
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? id,
+    required String surname,
+    required int salary,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, surname.asExpr, salary.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_join_expression/group_by_join_expression_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_join_expression/group_by_join_expression_test.g.dart
@@ -104,6 +104,16 @@ extension TableDepartmentExt on Table<Department> {
     required Expr<String> name,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, name]);
 
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({int? id, required String name}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, name.asExpr],
+      );
+
   /// Delete a single row from the `departments` table, specified by
   /// _primary key_.
   ///
@@ -359,6 +369,20 @@ extension TableEmployeeExt on Table<Employee> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [id, name, deptId, salary],
+  );
+
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? id,
+    required String name,
+    required int deptId,
+    required int salary,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, name.asExpr, deptId.asExpr, salary.asExpr],
   );
 
   /// Delete a single row from the `employees` table, specified by

--- a/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
@@ -129,6 +129,20 @@ extension TableEmployeeExt on Table<Employee> {
     values: [id, surname, seniority, salary],
   );
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? id,
+    required String surname,
+    required String seniority,
+    int? salary,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, surname.asExpr, seniority.asExpr, salary.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
@@ -103,6 +103,16 @@ extension TableAuthorExt on Table<Author> {
     required Expr<String> name,
   }) => $ForGeneratedCode.insertInto(table: this, values: [authorId, name]);
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({int? authorId, required String name}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [authorId?.asExpr, name.asExpr],
+      );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -405,6 +415,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required int authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
@@ -129,6 +129,20 @@ extension TableEmployeeExt on Table<Employee> {
     values: [id, surname, seniority, salary],
   );
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? id,
+    required String surname,
+    required String seniority,
+    int? salary,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, surname.asExpr, seniority.asExpr, salary.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
@@ -123,6 +123,19 @@ extension TableEmployeeExt on Table<Employee> {
     values: [employeeId, name, departmentId],
   );
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? employeeId,
+    required String name,
+    int? departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId?.asExpr, name.asExpr, departmentId.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///
@@ -381,6 +394,19 @@ extension TableDepartmentExt on Table<Department> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [departmentId, name, location],
+  );
+
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({
+    int? departmentId,
+    required String name,
+    required String location,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [departmentId?.asExpr, name.asExpr, location.asExpr],
   );
 
   /// Delete a single row from the `departments` table, specified by

--- a/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
@@ -123,6 +123,19 @@ extension TableEmployeeExt on Table<Employee> {
     values: [employeeId, name, departmentId],
   );
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? employeeId,
+    required String name,
+    int? departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId?.asExpr, name.asExpr, departmentId.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///
@@ -381,6 +394,19 @@ extension TableDepartmentExt on Table<Department> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [departmentId, name, location],
+  );
+
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({
+    int? departmentId,
+    required String name,
+    required String location,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [departmentId?.asExpr, name.asExpr, location.asExpr],
   );
 
   /// Delete a single row from the `departments` table, specified by

--- a/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
@@ -132,6 +132,19 @@ extension TableEmployeeExt on Table<Employee> {
     values: [employeeId, name, departmentId],
   );
 
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? employeeId,
+    required String name,
+    int? departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId?.asExpr, name.asExpr, departmentId.asExpr],
+  );
+
   /// Delete a single row from the `employees` table, specified by
   /// _primary key_.
   ///
@@ -443,6 +456,19 @@ extension TableDepartmentExt on Table<Department> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [departmentId, name, location],
+  );
+
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({
+    int? departmentId,
+    required String name,
+    required String location,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [departmentId?.asExpr, name.asExpr, location.asExpr],
   );
 
   /// Delete a single row from the `departments` table, specified by

--- a/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
+++ b/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
@@ -114,6 +114,19 @@ extension TableItemExt on Table<Item> {
     Expr<String?>? value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    required int id,
+    required String name,
+    String? value,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id.asExpr, name.asExpr, value.asExpr],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
@@ -102,6 +102,18 @@ extension TableItemExt on Table<Item> {
     required Expr<String> value,
   }) => $ForGeneratedCode.insertInto(table: this, values: [key, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    required String key,
+    required String value,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [key.asExpr, value.asExpr],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/blob/blob_test.dart
+++ b/typed_sql/test/typed_sql/nullable/blob/blob_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().deepEquals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/blob/blob_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/blob/blob_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<Uint8List?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, Uint8List? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().equals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<bool?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, bool? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().equals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<DateTime?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, DateTime? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().equals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<int?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, int? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().deepEquals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<JsonValue?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, JsonValue? value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().equals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<double?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, double? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.dart
@@ -67,6 +67,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().equals(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(

--- a/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
@@ -98,6 +98,13 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, Expr<String?>? value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, String? value}) => $ForGeneratedCode
+      .insertInto(table: this, values: [id?.asExpr, value.asExpr]);
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
@@ -144,6 +144,27 @@ extension TableItemExt on Table<Item> {
     values: [id, text, real, timestamp, integer],
   );
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({
+    int? id,
+    required String text,
+    required double real,
+    required DateTime timestamp,
+    int? integer,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      id?.asExpr,
+      text.asExpr,
+      real.asExpr,
+      timestamp.asExpr,
+      integer.asExpr,
+    ],
+  );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
@@ -128,6 +128,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, name, favoriteBookId],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String name,
+    int? favoriteBookId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, name.asExpr, favoriteBookId.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -564,6 +577,27 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, editorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required int authorId,
+    int? editorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      bookId?.asExpr,
+      title.asExpr,
+      authorId.asExpr,
+      editorId.asExpr,
+      stock.asExpr,
+    ],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
+++ b/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
@@ -119,6 +119,19 @@ extension TableAuthorExt on Table<Author> {
     values: [authorId, firstname, lastname],
   );
 
+  /// Insert row into the `authors` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Author> insertValue({
+    int? authorId,
+    required String firstname,
+    required String lastname,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [authorId?.asExpr, firstname.asExpr, lastname.asExpr],
+  );
+
   /// Delete a single row from the `authors` table, specified by
   /// _primary key_.
   ///
@@ -451,6 +464,20 @@ extension TableBookExt on Table<Book> {
   }) => $ForGeneratedCode.insertInto(
     table: this,
     values: [bookId, title, authorId, stock],
+  );
+
+  /// Insert row into the `books` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Book> insertValue({
+    int? bookId,
+    required String title,
+    required int authorId,
+    required int stock,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [bookId?.asExpr, title.asExpr, authorId.asExpr, stock.asExpr],
   );
 
   /// Delete a single row from the `books` table, specified by

--- a/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
@@ -98,6 +98,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<DateTime> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required DateTime value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/composite_unique/composite_unique_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/composite_unique/composite_unique_test.g.dart
@@ -125,6 +125,19 @@ extension TableUserExt on Table<User> {
     values: [accountId, firstName, lastName],
   );
 
+  /// Insert row into the `users` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<User> insertValue({
+    int? accountId,
+    required String firstName,
+    required String lastName,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, firstName.asExpr, lastName.asExpr],
+  );
+
   /// Delete a single row from the `users` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_boolean/unique_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_boolean/unique_boolean_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<bool> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required bool value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_integer/unique_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_integer/unique_integer_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<int> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required int value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_real/unique_real_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_real/unique_real_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<double> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required double value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_text/unique_text_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_text/unique_text_test.g.dart
@@ -105,6 +105,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<String> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required String value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_zero_real/unique_zero_real_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_zero_real/unique_zero_real_test.g.dart
@@ -103,6 +103,16 @@ extension TableItemExt on Table<Item> {
   InsertSingle<Item> insert({Expr<int>? id, required Expr<double> value}) =>
       $ForGeneratedCode.insertInto(table: this, values: [id, value]);
 
+  /// Insert row into the `items` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Item> insertValue({int? id, required double value}) =>
+      $ForGeneratedCode.insertInto(
+        table: this,
+        values: [id?.asExpr, value.asExpr],
+      );
+
   /// Delete a single row from the `items` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
@@ -121,6 +121,19 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber, balance],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
@@ -121,6 +121,19 @@ extension TableAccountExt on Table<Account> {
     values: [accountId, accountNumber, balance],
   );
 
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    String? accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
   /// Delete a single row from the `accounts` table, specified by
   /// _primary key_.
   ///

--- a/typed_sql/tool/generate_crud_tests.dart
+++ b/typed_sql/tool/generate_crud_tests.dart
@@ -174,11 +174,35 @@ void main() {
     check(item).isNotNull().value.{{equality}}(initialValue);
   });
 
+  r.addTest('.insertValue()', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.{{equality}}(initialValue);
+  });
+
   r.addTest('.insert(value: empty)', (db) async {
     await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(emptyValue),
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.{{equality}}(emptyValue);
+  });
+
+  r.addTest('.insertValue(value: empty)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: emptyValue,
         )
         .execute();
 
@@ -198,6 +222,18 @@ void main() {
     check(item).isNotNull().value.{{equality}}(otherValue);
   });
 
+  r.addTest('.insertValue(value: other)', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: otherValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.{{equality}}(otherValue);
+  });
+
   r.addTest('.insert().returnInserted()', (db) async {
     final item = await db.items
         .insert(
@@ -209,11 +245,33 @@ void main() {
     check(item).isNotNull().value.{{equality}}(initialValue);
   });
 
+  r.addTest('.insertValue().returnInserted()', (db) async {
+    final item = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .returnInserted()
+        .executeAndFetch();
+    check(item).isNotNull().value.{{equality}}(initialValue);
+  });
+
   r.addTest('.insert().returning(.value)', (db) async {
     final value = await db.items
         .insert(
           id: toExpr(1),
           value: toExpr(initialValue),
+        )
+        .returning((item) => (item.value,))
+        .executeAndFetch();
+    check(value).isNotNull().{{equality}}(initialValue);
+  });
+
+  r.addTest('.insertValue().returning(.value)', (db) async {
+    final value = await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
         )
         .returning((item) => (item.value,))
         .executeAndFetch();

--- a/typed_sql/tool/generate_custom_type_tests.dart
+++ b/typed_sql/tool/generate_custom_type_tests.dart
@@ -174,6 +174,18 @@ void main() {
     check(item).isNotNull().value.equals(initialValue);
   });
 
+  r.addTest('insertValue', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: initialValue,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.equals(initialValue);
+  });
+
   r.addTest('update', (db) async {
     await db.items
         .insert(

--- a/typed_sql/tool/generate_default_tests.dart
+++ b/typed_sql/tool/generate_default_tests.dart
@@ -75,6 +75,13 @@ final instances = [
     'equality': 'equals',
   },
   {
+    'name': 'default_nullable_text',
+    'type': 'String?',
+    'defaultValue': '\'hello\'',
+    'nonDefaultValue': '\'hello world\'',
+    'equality': 'equals',
+  },
+  {
     'name': 'default_boolean',
     'type': 'bool',
     'defaultValue': 'true',

--- a/typed_sql/tool/generate_nullable_tests.dart
+++ b/typed_sql/tool/generate_nullable_tests.dart
@@ -173,6 +173,41 @@ void main() {
     check(item).isNotNull().value.isNull();
   });
 
+  r.addTest('.insertValue() non-null value', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: _value,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNotNull().{{equality}}(_value);
+  });
+
+  r.addTest('.insertValue() null by default', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
+  r.addTest('.insertValue() null explicitly', (db) async {
+    await db.items
+        .insertValue(
+          id: 1,
+          value: null,
+        )
+        .execute();
+
+    final item = await db.items.first.fetch();
+    check(item).isNotNull().value.isNull();
+  });
+
   r.addTest('.update() null by default', (db) async {
     await db.items
         .insert(


### PR DESCRIPTION
Please **focus review on the first commit**, the second is updates to generated files.

This introduces `.insertValue` for convenience. 

I've hesitated to do this earlier because of the issue with `null` vs optional parameter being omitted.

I've narrowed it down such that:
 * Non-nullable fields that have a default value are optional named parameters (meaning parameter is nullable).
 * nullable fields that don't have a default value are optional named parameters (obviously the parameter is nullable).
 * nullable fields that have a default value are **required** named parameters (and users cannot insert the default value!).