### PR TITLE
Fix json path

### DIFF
--- a/typed_sql/lib/src/dialect/mysql_dialect.dart
+++ b/typed_sql/lib/src/dialect/mysql_dialect.dart
@@ -29,15 +29,76 @@ String _literal(dynamic value) => switch (value) {
   false => 'FALSE',
   int i => i.toString(),
   double d => d.toString(),
-  String s => "'${s.replaceAll("'", "''").replaceAll("\\", "\\\\")}'",
+  String s => _escapeStringLiteral(s),
   DateTime d =>
     "'${d.toIso8601String().substring(0, 19).replaceFirst('T', ' ')}'",
   Uint8List b =>
     "X'${b.map((b) => b.toRadixString(16).padLeft(2, '0')).join()}'",
   JsonValue j =>
-    '(\'${json.encode(normalizeJson(j.value)).replaceAll("'", "''").replaceAll("\\", "\\\\")}\')',
+    '(${_escapeStringLiteral(json.encode(normalizeJson(j.value)))})',
   _ => throw UnsupportedError('Unable to encode "$value" as a literal'),
 };
+
+/// Escapes a string literal for safe inlining into MySQL/MariaDB queries.
+/// Assumes standard MySQL behavior (NO_BACKSLASH_ESCAPES is OFF).
+String _escapeStringLiteral(String input) {
+  // Fast Path
+  var needsEscaping = false;
+  for (var i = 0; i < input.length; i++) {
+    final codeUnit = input.codeUnitAt(i);
+    // 39 = '  | 34 = "  | 92 = \  | 0 = \x00
+    // 10 = \n | 13 = \r | 26 = \x1A
+    if (codeUnit == 39 ||
+        codeUnit == 92 ||
+        codeUnit == 0 ||
+        codeUnit == 10 ||
+        codeUnit == 13 ||
+        codeUnit == 26 ||
+        codeUnit == 34) {
+      needsEscaping = true;
+      break;
+    }
+  }
+
+  if (!needsEscaping) {
+    return "'$input'";
+  }
+
+  final buffer = StringBuffer();
+  buffer.write("'");
+
+  for (var i = 0; i < input.length; i++) {
+    final char = input[i];
+    switch (char) {
+      case '\x00':
+        buffer.write(r'\0');
+        break;
+      case '\n':
+        buffer.write(r'\n');
+        break;
+      case '\r':
+        buffer.write(r'\r');
+        break;
+      case '\\':
+        buffer.write(r'\\');
+        break;
+      case "'":
+        buffer.write(r"\'");
+        break;
+      case '"':
+        buffer.write(r'\"');
+        break;
+      case '\x1A':
+        buffer.write(r'\Z');
+        break;
+      default:
+        buffer.write(char);
+    }
+  }
+
+  buffer.write("'");
+  return buffer.toString();
+}
 
 final class _MysqlSqlDialect extends SqlDialect {
   @override
@@ -599,7 +660,7 @@ extension on ExpressionResolver<SqlContext> {
 
   String extractJsonRef(ExpressionJsonRef ref) {
     final (root, path) = _compileJsonPath(ref);
-    return 'JSON_EXTRACT(${expr(root)}, ${context.addParameter(path)})';
+    return 'JSON_EXTRACT(${expr(root)}, ${_escapeStringLiteral(path)})';
   }
 
   /// Recursively builds the root expression and the MySQL JSON path string.

--- a/typed_sql/lib/src/dialect/postgres_dialect.dart
+++ b/typed_sql/lib/src/dialect/postgres_dialect.dart
@@ -28,12 +28,32 @@ String _literal(Object? value) => switch (value) {
   false => 'FALSE',
   int i => i.toString(),
   double d => d.toString(),
-  String s => '\'${s.replaceAll("'", "''").replaceAll("\\", "\\\\")}\'',
+  String s => _escapeStringLiteral(s),
   DateTime d => '\'${d.toIso8601String()}\'',
-  JsonValue j =>
-    '\'${json.encode(j.value).replaceAll("'", "''").replaceAll("\\", "\\\\")}\'::jsonb',
+  JsonValue j => '${_escapeStringLiteral(json.encode(j.value))}::jsonb',
   _ => throw UnsupportedError('Unable to encode "$value" as a literal'),
 };
+
+/// Escapes a string literal for safe inlining into PostgreSQL queries.
+/// Assumes standard_conforming_strings = on.
+String _escapeStringLiteral(String input) {
+  var needsEscaping = false;
+  // 1. Fast Path
+  for (var i = 0; i < input.length; i++) {
+    final codeUnit = input.codeUnitAt(i);
+    // 39 = Single Quote (') | 0 = Null Byte (\x00)
+    if (codeUnit == 39 || codeUnit == 0) {
+      needsEscaping = true;
+      break;
+    }
+  }
+  if (!needsEscaping) {
+    return "'$input'";
+  }
+
+  final sanitized = input.replaceAll('\x00', '');
+  return "'${sanitized.replaceAll("'", "''")}'";
+}
 
 final class _PostgresDialect extends SqlDialect {
   @override
@@ -601,7 +621,8 @@ extension on ExpressionResolver<SqlContext> {
     if (path.isEmpty) {
       return expr(root);
     }
-    return '(${expr(root)} #> ARRAY[${path.map(context.addParameter).join(', ')}])';
+    final pathElements = path.map(_escapeStringLiteral).join(', ');
+    return '(${expr(root)} #> ARRAY[$pathElements])';
   }
 
   /// Unwinds the recursive reference into a flat list of path segments.

--- a/typed_sql/lib/src/dialect/sqlite_dialect.dart
+++ b/typed_sql/lib/src/dialect/sqlite_dialect.dart
@@ -29,12 +29,32 @@ String _literal(Object? value) => switch (value) {
   false => 'FALSE',
   int i => i.toString(),
   double d => d.toString(),
-  String s => '\'${s.replaceAll("'", "''").replaceAll("\\", "\\\\")}\'',
+  String s => _escapeStringLiteral(s),
   DateTime d => '\'${d.toIso8601String()}\'',
   JsonValue j =>
-    'jsonb(\'${json.encode(normalizeJson(j.value)).replaceAll("'", "''").replaceAll("\\", "\\\\")}\')',
+    'jsonb(${_escapeStringLiteral(json.encode(normalizeJson(j.value)))})',
   _ => throw UnsupportedError('Unable to encode "$value" as a literal'),
 };
+
+/// Escapes a string literal for safe inlining into SQLite queries.
+String _escapeStringLiteral(String input) {
+  // 1. Fast Path: Scan for characters that require handling.
+  var needsEscaping = false;
+  for (var i = 0; i < input.length; i++) {
+    final codeUnit = input.codeUnitAt(i);
+    // 39 = Single Quote (')
+    // 0  = Null Byte (\x00)
+    if (codeUnit == 39 || codeUnit == 0) {
+      needsEscaping = true;
+      break;
+    }
+  }
+  if (!needsEscaping) {
+    return "'$input'";
+  }
+  final sanitized = input.replaceAll('\x00', '');
+  return "'${sanitized.replaceAll("'", "''")}'";
+}
 
 final class _Sqlite extends SqlDialect {
   @override
@@ -577,7 +597,7 @@ extension on ExpressionResolver<SqlContext> {
     //
     // This follows the JSON Path returns string encoded JSON and then
     // re-encodes as JSONB.
-    return 'jsonb(${expr(root)} -> ${context.addParameter(path)})';
+    return 'jsonb(${expr(root)} -> ${_escapeStringLiteral(path)})';
   }
 
   String extractJsonRefAsText(ExpressionJsonRef ref) {
@@ -585,7 +605,7 @@ extension on ExpressionResolver<SqlContext> {
     // This is an efficient implementation of ExpressionJsonExtract for
     // ExpressionJsonRef, since ExpressionJsonRef otherwise has to be converted
     // to JSON string and then re-encoded as JSONB.
-    return '(${expr(root)} ->> ${context.addParameter(path)})';
+    return '(${expr(root)} ->> ${_escapeStringLiteral(path)})';
   }
 
   /// Get root and path from [ref].

--- a/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.dart
+++ b/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.dart
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'advanced_composite_fk_test.g.dart';
+
+abstract final class BlogDatabase extends Schema {
+  Table<Post> get posts;
+  Table<Comment> get comments;
+}
+
+@PrimaryKey(['author', 'slug'])
+abstract final class Post extends Row {
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get author;
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get slug;
+
+  String get content;
+}
+
+@PrimaryKey(['commentId'])
+@ForeignKey(
+  ['author', 'postSlug'],
+  table: 'posts',
+  fields: ['author', 'slug'],
+  name: 'post',
+  as: 'comments',
+)
+abstract final class Comment extends Row {
+  @AutoIncrement()
+  int get commentId;
+
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get author;
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get postSlug;
+
+  String get comment;
+}
+
+void main() {
+  final r = TestRunner<BlogDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('Query with composite FK subquery', (db) async {
+    await db.posts
+        .insertValue(author: 'alice', slug: 'hello', content: 'world')
+        .execute();
+    await db.comments
+        .insertValue(author: 'alice', postSlug: 'hello', comment: 'nice')
+        .execute();
+
+    final result = await db.comments
+        .select(
+          (c) => (
+            c.comment,
+            c.post.content,
+          ),
+        )
+        .fetch();
+
+    check(result).unorderedEquals([
+      ('nice', 'world'),
+    ]);
+  });
+
+  r.addTest('Query with composite FK reverse lookup (as comments)', (db) async {
+    await db.posts
+        .insertValue(author: 'alice', slug: 'hello', content: 'world')
+        .execute();
+    await db.comments
+        .insertValue(author: 'alice', postSlug: 'hello', comment: 'nice1')
+        .execute();
+    await db.comments
+        .insertValue(author: 'alice', postSlug: 'hello', comment: 'nice2')
+        .execute();
+
+    final result = await db.posts
+        .select(
+          (p) => (
+            p.slug,
+            p.comments.count(),
+          ),
+        )
+        .fetch();
+
+    check(result).unorderedEquals([
+      ('hello', 2),
+    ]);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.g.dart
@@ -1,0 +1,872 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'advanced_composite_fk_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [BlogDatabase].
+extension BlogDatabaseSchema on Database<BlogDatabase> {
+  static final _$tables = [_$Post._$table, _$Comment._$table];
+
+  Table<Post> get posts => $ForGeneratedCode.declareTable(this, _$Post._$table);
+
+  Table<Comment> get comments =>
+      $ForGeneratedCode.declareTable(this, _$Comment._$table);
+
+  /// Create tables defined in [BlogDatabase].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [BlogDatabase]. In production it's often better to
+  /// use [createBlogDatabaseTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [BlogDatabase].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [BlogDatabase]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createBlogDatabaseTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: BlogDatabaseSchema._$tables);
+
+final class _$Post extends Post {
+  _$Post._(this.author, this.slug, this.content);
+
+  @override
+  final String author;
+
+  @override
+  final String slug;
+
+  @override
+  final String content;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'posts',
+    columns: <String>['author', 'slug', 'content'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['author', 'slug'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Post._$fromDatabase,
+  );
+
+  static Post? _$fromDatabase(RowReader row) {
+    final author = row.readString();
+    final slug = row.readString();
+    final content = row.readString();
+    if (author == null && slug == null && content == null) {
+      return null;
+    }
+    return _$Post._(author!, slug!, content!);
+  }
+
+  @override
+  String toString() =>
+      'Post(author: "$author", slug: "$slug", content: "$content")';
+}
+
+/// Extension methods for table defined in [Post].
+extension TablePostExt on Table<Post> {
+  /// Insert row into the `posts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Post> insert({
+    required Expr<String> author,
+    required Expr<String> slug,
+    required Expr<String> content,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [author, slug, content],
+  );
+
+  /// Insert row into the `posts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Post> insertValue({
+    required String author,
+    required String slug,
+    required String content,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [author.asExpr, slug.asExpr, content.asExpr],
+  );
+
+  /// Delete a single row from the `posts` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Post> delete(String author, String slug) =>
+      $ForGeneratedCode.deleteSingle(byKey(author, slug), _$Post._$table);
+}
+
+/// Extension methods for building queries against the `posts` table.
+extension QueryPostExt on Query<(Expr<Post>,)> {
+  /// Lookup a single row in `posts` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Post>,)> byKey(String author, String slug) => where(
+    (post) => post.author.equalsValue(author) & post.slug.equalsValue(slug),
+  ).first;
+
+  /// Update all rows in the `posts` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Post> update(
+    UpdateSet<Post> Function(
+      Expr<Post> post,
+      UpdateSet<Post> Function({
+        Expr<String> author,
+        Expr<String> slug,
+        Expr<String> content,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Post>(
+    this,
+    _$Post._$table,
+    (post) => updateBuilder(
+      post,
+      ({Expr<String>? author, Expr<String>? slug, Expr<String>? content}) =>
+          $ForGeneratedCode.buildUpdate<Post>([author, slug, content]),
+    ),
+  );
+
+  /// Delete all rows in the `posts` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Post> delete() => $ForGeneratedCode.delete(this, _$Post._$table);
+}
+
+/// Extension methods for building point queries against the `posts` table.
+extension QuerySinglePostExt on QuerySingle<(Expr<Post>,)> {
+  /// Update the row (if any) in the `posts` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Post> update(
+    UpdateSet<Post> Function(
+      Expr<Post> post,
+      UpdateSet<Post> Function({
+        Expr<String> author,
+        Expr<String> slug,
+        Expr<String> content,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Post>(
+    this,
+    _$Post._$table,
+    (post) => updateBuilder(
+      post,
+      ({Expr<String>? author, Expr<String>? slug, Expr<String>? content}) =>
+          $ForGeneratedCode.buildUpdate<Post>([author, slug, content]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `posts` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Post> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Post._$table);
+}
+
+/// Extension methods for expressions on a row in the `posts` table.
+extension ExpressionPostExt on Expr<Post> {
+  Expr<String> get author =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.text);
+
+  Expr<String> get slug =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String> get content =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  /// Get [SubQuery] of rows from the `comments` table which
+  /// reference this row.
+  ///
+  /// This returns a [SubQuery] of [Comment] rows,
+  /// where [Comment.author], [Comment.postSlug]
+  /// references [Post.author], [Post.slug]
+  /// in this row.
+  SubQuery<(Expr<Comment>,)> get comments => $ForGeneratedCode
+      .subqueryTable(_$Comment._$table)
+      .where((r) => r.author.equals(author) & r.postSlug.equals(slug));
+}
+
+extension ExpressionNullablePostExt on Expr<Post?> {
+  Expr<String?> get author =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.text);
+
+  Expr<String?> get slug =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String?> get content =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  /// Get [SubQuery] of rows from the `comments` table which
+  /// reference this row.
+  ///
+  /// This returns a [SubQuery] of [Comment] rows,
+  /// where [Comment.author], [Comment.postSlug]
+  /// references [Post.author], [Post.slug]
+  /// in this row, if any.
+  ///
+  /// If this row is `NULL` the subquery is always be empty.
+  SubQuery<(Expr<Comment>,)> get comments => $ForGeneratedCode
+      .subqueryTable(_$Comment._$table)
+      .where(
+        (r) =>
+            r.author.equalsUnlessNull(author).asNotNull() &
+            r.postSlug.equalsUnlessNull(slug).asNotNull(),
+      );
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => author.isNotNull() & slug.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+extension InnerJoinPostCommentExt
+    on InnerJoin<(Expr<Post>,), (Expr<Comment>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Post.author] = [Comment.author] and [Post.slug] = [Comment.postSlug].
+  Query<(Expr<Post>, Expr<Comment>)> usingPost() =>
+      on((a, b) => a.author.equals(b.author) & a.slug.equals(b.postSlug));
+}
+
+extension LeftJoinPostCommentExt on LeftJoin<(Expr<Post>,), (Expr<Comment>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Post.author] = [Comment.author] and [Post.slug] = [Comment.postSlug].
+  Query<(Expr<Post>, Expr<Comment?>)> usingPost() =>
+      on((a, b) => a.author.equals(b.author) & a.slug.equals(b.postSlug));
+}
+
+extension RightJoinPostCommentExt
+    on RightJoin<(Expr<Post>,), (Expr<Comment>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Post.author] = [Comment.author] and [Post.slug] = [Comment.postSlug].
+  Query<(Expr<Post?>, Expr<Comment>)> usingPost() =>
+      on((a, b) => a.author.equals(b.author) & a.slug.equals(b.postSlug));
+}
+
+/// `Table<Post>` conflict targets for use with `.onConflict`.
+enum PostConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `author`, `slug`.
+  primaryKey(['author', 'slug']);
+
+  const PostConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSinglePostExt on InsertSingle<Post> {
+  InsertOnConflictSingle<Post> onConflict(PostConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSinglePostExt on InsertOnConflictSingle<Post> {
+  UpsertOne<Post> update(
+    UpdateSet<Post> Function(
+      Expr<Post> post,
+      Expr<Post> excluded,
+      UpdateSet<Post> Function({
+        Expr<String> author,
+        Expr<String> slug,
+        Expr<String> content,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Post>(
+    this,
+    (post, excluded) => updateBuilder(
+      post,
+      excluded,
+      ({Expr<String>? author, Expr<String>? slug, Expr<String>? content}) =>
+          $ForGeneratedCode.buildUpdate<Post>([author, slug, content]),
+    ),
+  );
+}
+
+final class _$Comment extends Comment {
+  _$Comment._(this.commentId, this.author, this.postSlug, this.comment);
+
+  @override
+  final int commentId;
+
+  @override
+  final String author;
+
+  @override
+  final String postSlug;
+
+  @override
+  final String comment;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'comments',
+    columns: <String>['commentId', 'author', 'postSlug', 'comment'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['commentId'],
+    unique: <List<String>>[],
+    foreignKeys: [
+      $ForGeneratedCode.foreignKeyDefinition(
+        name: 'post',
+        columns: ['author', 'postSlug'],
+        referencedTable: 'posts',
+        referencedColumns: ['author', 'slug'],
+        onDelete: .noAction,
+        onUpdate: .noAction,
+      ),
+    ],
+    readRow: _$Comment._$fromDatabase,
+  );
+
+  static Comment? _$fromDatabase(RowReader row) {
+    final commentId = row.readInt();
+    final author = row.readString();
+    final postSlug = row.readString();
+    final comment = row.readString();
+    if (commentId == null &&
+        author == null &&
+        postSlug == null &&
+        comment == null) {
+      return null;
+    }
+    return _$Comment._(commentId!, author!, postSlug!, comment!);
+  }
+
+  @override
+  String toString() =>
+      'Comment(commentId: "$commentId", author: "$author", postSlug: "$postSlug", comment: "$comment")';
+}
+
+/// Extension methods for table defined in [Comment].
+extension TableCommentExt on Table<Comment> {
+  /// Insert row into the `comments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Comment> insert({
+    Expr<int>? commentId,
+    required Expr<String> author,
+    required Expr<String> postSlug,
+    required Expr<String> comment,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [commentId, author, postSlug, comment],
+  );
+
+  /// Insert row into the `comments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Comment> insertValue({
+    int? commentId,
+    required String author,
+    required String postSlug,
+    required String comment,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [commentId?.asExpr, author.asExpr, postSlug.asExpr, comment.asExpr],
+  );
+
+  /// Delete a single row from the `comments` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Comment> delete(int commentId) =>
+      $ForGeneratedCode.deleteSingle(byKey(commentId), _$Comment._$table);
+}
+
+/// Extension methods for building queries against the `comments` table.
+extension QueryCommentExt on Query<(Expr<Comment>,)> {
+  /// Lookup a single row in `comments` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Comment>,)> byKey(int commentId) =>
+      where((comment) => comment.commentId.equalsValue(commentId)).first;
+
+  /// Update all rows in the `comments` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Comment> update(
+    UpdateSet<Comment> Function(
+      Expr<Comment> comment,
+      UpdateSet<Comment> Function({
+        Expr<int> commentId,
+        Expr<String> author,
+        Expr<String> postSlug,
+        Expr<String> comment,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Comment>(
+    this,
+    _$Comment._$table,
+    (comment) => updateBuilder(
+      comment,
+      ({
+        Expr<int>? commentId,
+        Expr<String>? author,
+        Expr<String>? postSlug,
+        Expr<String>? comment,
+      }) => $ForGeneratedCode.buildUpdate<Comment>([
+        commentId,
+        author,
+        postSlug,
+        comment,
+      ]),
+    ),
+  );
+
+  /// Delete all rows in the `comments` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Comment> delete() => $ForGeneratedCode.delete(this, _$Comment._$table);
+}
+
+/// Extension methods for building point queries against the `comments` table.
+extension QuerySingleCommentExt on QuerySingle<(Expr<Comment>,)> {
+  /// Update the row (if any) in the `comments` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Comment> update(
+    UpdateSet<Comment> Function(
+      Expr<Comment> comment,
+      UpdateSet<Comment> Function({
+        Expr<int> commentId,
+        Expr<String> author,
+        Expr<String> postSlug,
+        Expr<String> comment,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Comment>(
+    this,
+    _$Comment._$table,
+    (comment) => updateBuilder(
+      comment,
+      ({
+        Expr<int>? commentId,
+        Expr<String>? author,
+        Expr<String>? postSlug,
+        Expr<String>? comment,
+      }) => $ForGeneratedCode.buildUpdate<Comment>([
+        commentId,
+        author,
+        postSlug,
+        comment,
+      ]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `comments` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Comment> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Comment._$table);
+}
+
+/// Extension methods for expressions on a row in the `comments` table.
+extension ExpressionCommentExt on Expr<Comment> {
+  Expr<int> get commentId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get author =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String> get postSlug =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  Expr<String> get comment =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.text);
+
+  /// Do a subquery lookup of the row from table
+  /// `posts` referenced in
+  /// [author], [postSlug].
+  ///
+  /// The gets the row from table `posts` where
+  /// [Post.author], [Post.slug]
+  /// is equal to [author], [postSlug].
+  Expr<Post> get post => $ForGeneratedCode
+      .subqueryTable(_$Post._$table)
+      .where((r) => r.author.equals(author) & r.slug.equals(postSlug))
+      .first
+      .asNotNull();
+}
+
+extension ExpressionNullableCommentExt on Expr<Comment?> {
+  Expr<int?> get commentId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get author =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String?> get postSlug =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  Expr<String?> get comment =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.text);
+
+  /// Do a subquery lookup of the row from table
+  /// `posts` referenced in
+  /// [author], [postSlug].
+  ///
+  /// The gets the row from table `posts` where
+  /// [Post.author], [Post.slug]
+  /// is equal to [author], [postSlug], if any.
+  ///
+  /// If this row is `NULL` the subquery is always return `NULL`.
+  Expr<Post?> get post => $ForGeneratedCode
+      .subqueryTable(_$Post._$table)
+      .where(
+        (r) =>
+            r.author.equalsUnlessNull(author).asNotNull() &
+            r.slug.equalsUnlessNull(postSlug).asNotNull(),
+      )
+      .first;
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => commentId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+extension InnerJoinCommentPostExt
+    on InnerJoin<(Expr<Comment>,), (Expr<Post>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Comment.author] = [Post.author] and [Comment.postSlug] = [Post.slug].
+  Query<(Expr<Comment>, Expr<Post>)> usingPost() =>
+      on((a, b) => b.author.equals(a.author) & b.slug.equals(a.postSlug));
+}
+
+extension LeftJoinCommentPostExt on LeftJoin<(Expr<Comment>,), (Expr<Post>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Comment.author] = [Post.author] and [Comment.postSlug] = [Post.slug].
+  Query<(Expr<Comment>, Expr<Post?>)> usingPost() =>
+      on((a, b) => b.author.equals(a.author) & b.slug.equals(a.postSlug));
+}
+
+extension RightJoinCommentPostExt
+    on RightJoin<(Expr<Comment>,), (Expr<Post>,)> {
+  /// Join using the `post` _foreign key_.
+  ///
+  /// This will match rows where [Comment.author] = [Post.author] and [Comment.postSlug] = [Post.slug].
+  Query<(Expr<Comment?>, Expr<Post>)> usingPost() =>
+      on((a, b) => b.author.equals(a.author) & b.slug.equals(a.postSlug));
+}
+
+/// `Table<Comment>` conflict targets for use with `.onConflict`.
+enum CommentConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `commentId`.
+  primaryKey(['commentId']);
+
+  const CommentConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleCommentExt on InsertSingle<Comment> {
+  InsertOnConflictSingle<Comment> onConflict(CommentConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleCommentExt on InsertOnConflictSingle<Comment> {
+  UpsertOne<Comment> update(
+    UpdateSet<Comment> Function(
+      Expr<Comment> comment,
+      Expr<Comment> excluded,
+      UpdateSet<Comment> Function({
+        Expr<int> commentId,
+        Expr<String> author,
+        Expr<String> postSlug,
+        Expr<String> comment,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Comment>(
+    this,
+    (comment, excluded) => updateBuilder(
+      comment,
+      excluded,
+      ({
+        Expr<int>? commentId,
+        Expr<String>? author,
+        Expr<String>? postSlug,
+        Expr<String>? comment,
+      }) => $ForGeneratedCode.buildUpdate<Comment>([
+        commentId,
+        author,
+        postSlug,
+        comment,
+      ]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Comment] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension CommentChecks on Subject<Comment> {
+  /// Create assertions on [Comment.commentId].
+  Subject<int> get commentId => has((m) => m.commentId, 'commentId');
+
+  /// Create assertions on [Comment.author].
+  Subject<String> get author => has((m) => m.author, 'author');
+
+  /// Create assertions on [Comment.postSlug].
+  Subject<String> get postSlug => has((m) => m.postSlug, 'postSlug');
+
+  /// Create assertions on [Comment.comment].
+  Subject<String> get comment => has((m) => m.comment, 'comment');
+}
+
+/// Extension methods for assertions on [Post] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension PostChecks on Subject<Post> {
+  /// Create assertions on [Post.author].
+  Subject<String> get author => has((m) => m.author, 'author');
+
+  /// Create assertions on [Post.slug].
+  Subject<String> get slug => has((m) => m.slug, 'slug');
+
+  /// Create assertions on [Post.content].
+  Subject<String> get content => has((m) => m.content, 'content');
+}

--- a/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.dart
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'complex_aggregations_test.g.dart';
+
+abstract final class CompanyDatabase extends Schema {
+  Table<Department> get departments;
+  Table<Employee> get employees;
+  Table<Project> get projects;
+}
+
+@PrimaryKey(['departmentId'])
+abstract final class Department extends Row {
+  @AutoIncrement()
+  int get departmentId;
+
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get name;
+}
+
+@PrimaryKey(['employeeId'])
+abstract final class Employee extends Row {
+  @AutoIncrement()
+  int get employeeId;
+
+  String get name;
+
+  @References(table: 'departments', field: 'departmentId')
+  int get departmentId;
+}
+
+@PrimaryKey(['projectId'])
+abstract final class Project extends Row {
+  @AutoIncrement()
+  int get projectId;
+
+  String get name;
+
+  @References(table: 'departments', field: 'departmentId')
+  int get departmentId;
+
+  int get budget;
+}
+
+void main() {
+  final r = TestRunner<CompanyDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('Complex aggregations with 3-way join and groupBy', (db) async {
+    await db.departments.insertValue(departmentId: 1, name: 'Eng').execute();
+    await db.departments.insertValue(departmentId: 2, name: 'Sales').execute();
+
+    await db.employees
+        .insertValue(employeeId: 1, name: 'Alice', departmentId: 1)
+        .execute();
+    await db.employees
+        .insertValue(employeeId: 2, name: 'Bob', departmentId: 1)
+        .execute();
+    await db.employees
+        .insertValue(employeeId: 3, name: 'Charlie', departmentId: 2)
+        .execute();
+
+    await db.projects
+        .insertValue(projectId: 1, name: 'P1', departmentId: 1, budget: 1000)
+        .execute();
+    await db.projects
+        .insertValue(projectId: 2, name: 'P2', departmentId: 1, budget: 2000)
+        .execute();
+    await db.projects
+        .insertValue(projectId: 3, name: 'P3', departmentId: 2, budget: 5000)
+        .execute();
+
+    final result = await db.departments
+        .join(db.employees)
+        .on((d, e) => d.departmentId.equals(e.departmentId))
+        .join(db.projects)
+        .on((d, e, p) => d.departmentId.equals(p.departmentId))
+        .groupBy((d, e, p) => (d.name,))
+        .aggregate(
+          (agg) => agg.count().sum((d, e, p) => p.budget),
+        )
+        .fetch();
+
+    check(result).unorderedEquals([
+      ('Eng', 4, 6000),
+      ('Sales', 1, 5000),
+    ]);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.g.dart
@@ -1,0 +1,1089 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'complex_aggregations_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [CompanyDatabase].
+extension CompanyDatabaseSchema on Database<CompanyDatabase> {
+  static final _$tables = [
+    _$Department._$table,
+    _$Employee._$table,
+    _$Project._$table,
+  ];
+
+  Table<Department> get departments =>
+      $ForGeneratedCode.declareTable(this, _$Department._$table);
+
+  Table<Employee> get employees =>
+      $ForGeneratedCode.declareTable(this, _$Employee._$table);
+
+  Table<Project> get projects =>
+      $ForGeneratedCode.declareTable(this, _$Project._$table);
+
+  /// Create tables defined in [CompanyDatabase].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [CompanyDatabase]. In production it's often better to
+  /// use [createCompanyDatabaseTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [CompanyDatabase].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [CompanyDatabase]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createCompanyDatabaseTables(SqlDialect dialect) =>
+    $ForGeneratedCode.createTableSchema(
+      dialect: dialect,
+      tables: CompanyDatabaseSchema._$tables,
+    );
+
+final class _$Department extends Department {
+  _$Department._(this.departmentId, this.name);
+
+  @override
+  final int departmentId;
+
+  @override
+  final String name;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'departments',
+    columns: <String>['departmentId', 'name'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+    ],
+    primaryKey: <String>['departmentId'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Department._$fromDatabase,
+  );
+
+  static Department? _$fromDatabase(RowReader row) {
+    final departmentId = row.readInt();
+    final name = row.readString();
+    if (departmentId == null && name == null) {
+      return null;
+    }
+    return _$Department._(departmentId!, name!);
+  }
+
+  @override
+  String toString() =>
+      'Department(departmentId: "$departmentId", name: "$name")';
+}
+
+/// Extension methods for table defined in [Department].
+extension TableDepartmentExt on Table<Department> {
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insert({
+    Expr<int>? departmentId,
+    required Expr<String> name,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [departmentId, name]);
+
+  /// Insert row into the `departments` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Department> insertValue({
+    int? departmentId,
+    required String name,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [departmentId?.asExpr, name.asExpr],
+  );
+
+  /// Delete a single row from the `departments` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Department> delete(int departmentId) =>
+      $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
+}
+
+/// Extension methods for building queries against the `departments` table.
+extension QueryDepartmentExt on Query<(Expr<Department>,)> {
+  /// Lookup a single row in `departments` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
+    (department) => department.departmentId.equalsValue(departmentId),
+  ).first;
+
+  /// Update all rows in the `departments` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Department> update(
+    UpdateSet<Department> Function(
+      Expr<Department> department,
+      UpdateSet<Department> Function({
+        Expr<int> departmentId,
+        Expr<String> name,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Department>(
+    this,
+    _$Department._$table,
+    (department) => updateBuilder(
+      department,
+      ({Expr<int>? departmentId, Expr<String>? name}) =>
+          $ForGeneratedCode.buildUpdate<Department>([departmentId, name]),
+    ),
+  );
+
+  /// Delete all rows in the `departments` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Department> delete() =>
+      $ForGeneratedCode.delete(this, _$Department._$table);
+}
+
+/// Extension methods for building point queries against the `departments` table.
+extension QuerySingleDepartmentExt on QuerySingle<(Expr<Department>,)> {
+  /// Update the row (if any) in the `departments` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Department> update(
+    UpdateSet<Department> Function(
+      Expr<Department> department,
+      UpdateSet<Department> Function({
+        Expr<int> departmentId,
+        Expr<String> name,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Department>(
+    this,
+    _$Department._$table,
+    (department) => updateBuilder(
+      department,
+      ({Expr<int>? departmentId, Expr<String>? name}) =>
+          $ForGeneratedCode.buildUpdate<Department>([departmentId, name]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `departments` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Department> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Department._$table);
+}
+
+/// Extension methods for expressions on a row in the `departments` table.
+extension ExpressionDepartmentExt on Expr<Department> {
+  Expr<int> get departmentId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+}
+
+extension ExpressionNullableDepartmentExt on Expr<Department?> {
+  Expr<int?> get departmentId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => departmentId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Department>` conflict targets for use with `.onConflict`.
+enum DepartmentConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `departmentId`.
+  primaryKey(['departmentId']);
+
+  const DepartmentConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleDepartmentExt on InsertSingle<Department> {
+  InsertOnConflictSingle<Department> onConflict(DepartmentConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleDepartmentExt
+    on InsertOnConflictSingle<Department> {
+  UpsertOne<Department> update(
+    UpdateSet<Department> Function(
+      Expr<Department> department,
+      Expr<Department> excluded,
+      UpdateSet<Department> Function({
+        Expr<int> departmentId,
+        Expr<String> name,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Department>(
+    this,
+    (department, excluded) => updateBuilder(
+      department,
+      excluded,
+      ({Expr<int>? departmentId, Expr<String>? name}) =>
+          $ForGeneratedCode.buildUpdate<Department>([departmentId, name]),
+    ),
+  );
+}
+
+final class _$Employee extends Employee {
+  _$Employee._(this.employeeId, this.name, this.departmentId);
+
+  @override
+  final int employeeId;
+
+  @override
+  final String name;
+
+  @override
+  final int departmentId;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'employees',
+    columns: <String>['employeeId', 'name', 'departmentId'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['employeeId'],
+    unique: <List<String>>[],
+    foreignKeys: [
+      $ForGeneratedCode.foreignKeyDefinition(
+        name: 'null',
+        columns: ['departmentId'],
+        referencedTable: 'departments',
+        referencedColumns: ['departmentId'],
+        onDelete: .noAction,
+        onUpdate: .noAction,
+      ),
+    ],
+    readRow: _$Employee._$fromDatabase,
+  );
+
+  static Employee? _$fromDatabase(RowReader row) {
+    final employeeId = row.readInt();
+    final name = row.readString();
+    final departmentId = row.readInt();
+    if (employeeId == null && name == null && departmentId == null) {
+      return null;
+    }
+    return _$Employee._(employeeId!, name!, departmentId!);
+  }
+
+  @override
+  String toString() =>
+      'Employee(employeeId: "$employeeId", name: "$name", departmentId: "$departmentId")';
+}
+
+/// Extension methods for table defined in [Employee].
+extension TableEmployeeExt on Table<Employee> {
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insert({
+    Expr<int>? employeeId,
+    required Expr<String> name,
+    required Expr<int> departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId, name, departmentId],
+  );
+
+  /// Insert row into the `employees` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Employee> insertValue({
+    int? employeeId,
+    required String name,
+    required int departmentId,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [employeeId?.asExpr, name.asExpr, departmentId.asExpr],
+  );
+
+  /// Delete a single row from the `employees` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Employee> delete(int employeeId) =>
+      $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
+}
+
+/// Extension methods for building queries against the `employees` table.
+extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
+  /// Lookup a single row in `employees` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
+      where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Update all rows in the `employees` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Employee> update(
+    UpdateSet<Employee> Function(
+      Expr<Employee> employee,
+      UpdateSet<Employee> Function({
+        Expr<int> employeeId,
+        Expr<String> name,
+        Expr<int> departmentId,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Employee>(
+    this,
+    _$Employee._$table,
+    (employee) => updateBuilder(
+      employee,
+      ({Expr<int>? employeeId, Expr<String>? name, Expr<int>? departmentId}) =>
+          $ForGeneratedCode.buildUpdate<Employee>([
+            employeeId,
+            name,
+            departmentId,
+          ]),
+    ),
+  );
+
+  /// Delete all rows in the `employees` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Employee> delete() =>
+      $ForGeneratedCode.delete(this, _$Employee._$table);
+}
+
+/// Extension methods for building point queries against the `employees` table.
+extension QuerySingleEmployeeExt on QuerySingle<(Expr<Employee>,)> {
+  /// Update the row (if any) in the `employees` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Employee> update(
+    UpdateSet<Employee> Function(
+      Expr<Employee> employee,
+      UpdateSet<Employee> Function({
+        Expr<int> employeeId,
+        Expr<String> name,
+        Expr<int> departmentId,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Employee>(
+    this,
+    _$Employee._$table,
+    (employee) => updateBuilder(
+      employee,
+      ({Expr<int>? employeeId, Expr<String>? name, Expr<int>? departmentId}) =>
+          $ForGeneratedCode.buildUpdate<Employee>([
+            employeeId,
+            name,
+            departmentId,
+          ]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `employees` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Employee> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Employee._$table);
+}
+
+/// Extension methods for expressions on a row in the `employees` table.
+extension ExpressionEmployeeExt on Expr<Employee> {
+  Expr<int> get employeeId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<int> get departmentId =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
+}
+
+extension ExpressionNullableEmployeeExt on Expr<Employee?> {
+  Expr<int?> get employeeId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<int?> get departmentId =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => employeeId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Employee>` conflict targets for use with `.onConflict`.
+enum EmployeeConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `employeeId`.
+  primaryKey(['employeeId']);
+
+  const EmployeeConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleEmployeeExt on InsertSingle<Employee> {
+  InsertOnConflictSingle<Employee> onConflict(EmployeeConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleEmployeeExt
+    on InsertOnConflictSingle<Employee> {
+  UpsertOne<Employee> update(
+    UpdateSet<Employee> Function(
+      Expr<Employee> employee,
+      Expr<Employee> excluded,
+      UpdateSet<Employee> Function({
+        Expr<int> employeeId,
+        Expr<String> name,
+        Expr<int> departmentId,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Employee>(
+    this,
+    (employee, excluded) => updateBuilder(
+      employee,
+      excluded,
+      ({Expr<int>? employeeId, Expr<String>? name, Expr<int>? departmentId}) =>
+          $ForGeneratedCode.buildUpdate<Employee>([
+            employeeId,
+            name,
+            departmentId,
+          ]),
+    ),
+  );
+}
+
+final class _$Project extends Project {
+  _$Project._(this.projectId, this.name, this.departmentId, this.budget);
+
+  @override
+  final int projectId;
+
+  @override
+  final String name;
+
+  @override
+  final int departmentId;
+
+  @override
+  final int budget;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'projects',
+    columns: <String>['projectId', 'name', 'departmentId', 'budget'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['projectId'],
+    unique: <List<String>>[],
+    foreignKeys: [
+      $ForGeneratedCode.foreignKeyDefinition(
+        name: 'null',
+        columns: ['departmentId'],
+        referencedTable: 'departments',
+        referencedColumns: ['departmentId'],
+        onDelete: .noAction,
+        onUpdate: .noAction,
+      ),
+    ],
+    readRow: _$Project._$fromDatabase,
+  );
+
+  static Project? _$fromDatabase(RowReader row) {
+    final projectId = row.readInt();
+    final name = row.readString();
+    final departmentId = row.readInt();
+    final budget = row.readInt();
+    if (projectId == null &&
+        name == null &&
+        departmentId == null &&
+        budget == null) {
+      return null;
+    }
+    return _$Project._(projectId!, name!, departmentId!, budget!);
+  }
+
+  @override
+  String toString() =>
+      'Project(projectId: "$projectId", name: "$name", departmentId: "$departmentId", budget: "$budget")';
+}
+
+/// Extension methods for table defined in [Project].
+extension TableProjectExt on Table<Project> {
+  /// Insert row into the `projects` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Project> insert({
+    Expr<int>? projectId,
+    required Expr<String> name,
+    required Expr<int> departmentId,
+    required Expr<int> budget,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [projectId, name, departmentId, budget],
+  );
+
+  /// Insert row into the `projects` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Project> insertValue({
+    int? projectId,
+    required String name,
+    required int departmentId,
+    required int budget,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [
+      projectId?.asExpr,
+      name.asExpr,
+      departmentId.asExpr,
+      budget.asExpr,
+    ],
+  );
+
+  /// Delete a single row from the `projects` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Project> delete(int projectId) =>
+      $ForGeneratedCode.deleteSingle(byKey(projectId), _$Project._$table);
+}
+
+/// Extension methods for building queries against the `projects` table.
+extension QueryProjectExt on Query<(Expr<Project>,)> {
+  /// Lookup a single row in `projects` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Project>,)> byKey(int projectId) =>
+      where((project) => project.projectId.equalsValue(projectId)).first;
+
+  /// Update all rows in the `projects` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Project> update(
+    UpdateSet<Project> Function(
+      Expr<Project> project,
+      UpdateSet<Project> Function({
+        Expr<int> projectId,
+        Expr<String> name,
+        Expr<int> departmentId,
+        Expr<int> budget,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Project>(
+    this,
+    _$Project._$table,
+    (project) => updateBuilder(
+      project,
+      ({
+        Expr<int>? projectId,
+        Expr<String>? name,
+        Expr<int>? departmentId,
+        Expr<int>? budget,
+      }) => $ForGeneratedCode.buildUpdate<Project>([
+        projectId,
+        name,
+        departmentId,
+        budget,
+      ]),
+    ),
+  );
+
+  /// Delete all rows in the `projects` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Project> delete() => $ForGeneratedCode.delete(this, _$Project._$table);
+}
+
+/// Extension methods for building point queries against the `projects` table.
+extension QuerySingleProjectExt on QuerySingle<(Expr<Project>,)> {
+  /// Update the row (if any) in the `projects` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Project> update(
+    UpdateSet<Project> Function(
+      Expr<Project> project,
+      UpdateSet<Project> Function({
+        Expr<int> projectId,
+        Expr<String> name,
+        Expr<int> departmentId,
+        Expr<int> budget,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Project>(
+    this,
+    _$Project._$table,
+    (project) => updateBuilder(
+      project,
+      ({
+        Expr<int>? projectId,
+        Expr<String>? name,
+        Expr<int>? departmentId,
+        Expr<int>? budget,
+      }) => $ForGeneratedCode.buildUpdate<Project>([
+        projectId,
+        name,
+        departmentId,
+        budget,
+      ]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `projects` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Project> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Project._$table);
+}
+
+/// Extension methods for expressions on a row in the `projects` table.
+extension ExpressionProjectExt on Expr<Project> {
+  Expr<int> get projectId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<int> get departmentId =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
+
+  Expr<int> get budget =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.integer);
+}
+
+extension ExpressionNullableProjectExt on Expr<Project?> {
+  Expr<int?> get projectId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<int?> get departmentId =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
+
+  Expr<int?> get budget =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.integer);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => projectId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Project>` conflict targets for use with `.onConflict`.
+enum ProjectConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `projectId`.
+  primaryKey(['projectId']);
+
+  const ProjectConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleProjectExt on InsertSingle<Project> {
+  InsertOnConflictSingle<Project> onConflict(ProjectConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleProjectExt on InsertOnConflictSingle<Project> {
+  UpsertOne<Project> update(
+    UpdateSet<Project> Function(
+      Expr<Project> project,
+      Expr<Project> excluded,
+      UpdateSet<Project> Function({
+        Expr<int> projectId,
+        Expr<String> name,
+        Expr<int> departmentId,
+        Expr<int> budget,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Project>(
+    this,
+    (project, excluded) => updateBuilder(
+      project,
+      excluded,
+      ({
+        Expr<int>? projectId,
+        Expr<String>? name,
+        Expr<int>? departmentId,
+        Expr<int>? budget,
+      }) => $ForGeneratedCode.buildUpdate<Project>([
+        projectId,
+        name,
+        departmentId,
+        budget,
+      ]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Department] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension DepartmentChecks on Subject<Department> {
+  /// Create assertions on [Department.departmentId].
+  Subject<int> get departmentId => has((m) => m.departmentId, 'departmentId');
+
+  /// Create assertions on [Department.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+}
+
+/// Extension methods for assertions on [Employee] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension EmployeeChecks on Subject<Employee> {
+  /// Create assertions on [Employee.employeeId].
+  Subject<int> get employeeId => has((m) => m.employeeId, 'employeeId');
+
+  /// Create assertions on [Employee.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [Employee.departmentId].
+  Subject<int> get departmentId => has((m) => m.departmentId, 'departmentId');
+}
+
+/// Extension methods for assertions on [Project] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ProjectChecks on Subject<Project> {
+  /// Create assertions on [Project.projectId].
+  Subject<int> get projectId => has((m) => m.projectId, 'projectId');
+
+  /// Create assertions on [Project.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [Project.departmentId].
+  Subject<int> get departmentId => has((m) => m.departmentId, 'departmentId');
+
+  /// Create assertions on [Project.budget].
+  Subject<int> get budget => has((m) => m.budget, 'budget');
+}

--- a/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.dart
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'json_groupby_caveat_test.g.dart';
+
+abstract final class ProductCatalog extends Schema {
+  Table<Product> get products;
+}
+
+@PrimaryKey(['id'])
+abstract final class Product extends Row {
+  @AutoIncrement()
+  int get id;
+
+  String get name;
+
+  JsonValue get metadata;
+}
+
+void main() {
+  final r = TestRunner<ProductCatalog>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  // This will fail if we use parameterization to inject JSON paths, but we
+  // don't do that anymore.
+  r.addTest(
+    'GroupBy JSON field',
+    (db) async {
+      await db.products
+          .insertValue(name: 'A', metadata: const JsonValue({'category': 'X'}))
+          .execute();
+      await db.products
+          .insertValue(name: 'B', metadata: const JsonValue({'category': 'X'}))
+          .execute();
+      await db.products
+          .insertValue(name: 'C', metadata: const JsonValue({'category': 'Y'}))
+          .execute();
+
+      final counts = await db.products
+          .groupBy((p) => (p.metadata['category'].asString(),))
+          .aggregate((agg) => agg.count())
+          .fetch();
+
+      check(counts).unorderedEquals([
+        ('X', 2),
+        ('Y', 1),
+      ]);
+    },
+  );
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.g.dart
@@ -1,0 +1,362 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'json_groupby_caveat_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [ProductCatalog].
+extension ProductCatalogSchema on Database<ProductCatalog> {
+  static final _$tables = [_$Product._$table];
+
+  Table<Product> get products =>
+      $ForGeneratedCode.declareTable(this, _$Product._$table);
+
+  /// Create tables defined in [ProductCatalog].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [ProductCatalog]. In production it's often better to
+  /// use [createProductCatalogTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [ProductCatalog].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [ProductCatalog]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createProductCatalogTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: ProductCatalogSchema._$tables);
+
+final class _$Product extends Product {
+  _$Product._(this.id, this.name, this.metadata);
+
+  @override
+  final int id;
+
+  @override
+  final String name;
+
+  @override
+  final JsonValue metadata;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'products',
+    columns: <String>['id', 'name', 'metadata'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.jsonValue,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Product._$fromDatabase,
+  );
+
+  static Product? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final name = row.readString();
+    final metadata = row.readJsonValue();
+    if (id == null && name == null && metadata == null) {
+      return null;
+    }
+    return _$Product._(id!, name!, metadata!);
+  }
+
+  @override
+  String toString() =>
+      'Product(id: "$id", name: "$name", metadata: "$metadata")';
+}
+
+/// Extension methods for table defined in [Product].
+extension TableProductExt on Table<Product> {
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insert({
+    Expr<int>? id,
+    required Expr<String> name,
+    required Expr<JsonValue> metadata,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, metadata]);
+
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insertValue({
+    int? id,
+    required String name,
+    required JsonValue metadata,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, name.asExpr, metadata.asExpr],
+  );
+
+  /// Delete a single row from the `products` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Product> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
+}
+
+/// Extension methods for building queries against the `products` table.
+extension QueryProductExt on Query<(Expr<Product>,)> {
+  /// Lookup a single row in `products` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Product>,)> byKey(int id) =>
+      where((product) => product.id.equalsValue(id)).first;
+
+  /// Update all rows in the `products` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete all rows in the `products` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Product> delete() => $ForGeneratedCode.delete(this, _$Product._$table);
+}
+
+/// Extension methods for building point queries against the `products` table.
+extension QuerySingleProductExt on QuerySingle<(Expr<Product>,)> {
+  /// Update the row (if any) in the `products` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `products` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Product> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Product._$table);
+}
+
+/// Extension methods for expressions on a row in the `products` table.
+extension ExpressionProductExt on Expr<Product> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+}
+
+extension ExpressionNullableProductExt on Expr<Product?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue?> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Product>` conflict targets for use with `.onConflict`.
+enum ProductConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `id`.
+  primaryKey(['id']);
+
+  const ProductConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleProductExt on InsertSingle<Product> {
+  InsertOnConflictSingle<Product> onConflict(ProductConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleProductExt on InsertOnConflictSingle<Product> {
+  UpsertOne<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      Expr<Product> excluded,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Product>(
+    this,
+    (product, excluded) => updateBuilder(
+      product,
+      excluded,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Product] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ProductChecks on Subject<Product> {
+  /// Create assertions on [Product.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [Product.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [Product.metadata].
+  Subject<JsonValue> get metadata => has((m) => m.metadata, 'metadata');
+}

--- a/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.dart
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'upsert_multi_conflict_test.g.dart';
+
+abstract final class MultiConflictDatabase extends Schema {
+  Table<MultiItem> get multiItems;
+}
+
+@PrimaryKey(['id'])
+abstract final class MultiItem extends Row {
+  @AutoIncrement()
+  int get id;
+
+  @Unique.field()
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get name;
+
+  @Unique.field()
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get email;
+
+  int get value;
+}
+
+void main() {
+  final r = TestRunner<MultiConflictDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest(
+    'Conflict on name, target name -> update',
+    (db) async {
+      await db.multiItems
+          .insertValue(id: 1, name: 'A', email: 'a@e.com', value: 10)
+          .execute();
+
+      await db.multiItems
+          .insertValue(id: 2, name: 'A', email: 'b@e.com', value: 20)
+          .onConflict(MultiItemConflict.name)
+          .update((item, excluded, set) => set(value: excluded.value))
+          .execute();
+
+      final item = await db.multiItems
+          .where((i) => i.name.equalsValue('A'))
+          .first
+          .fetch();
+      check(item).isNotNull().id.equals(1);
+      check(item).isNotNull().value.equals(20);
+    },
+    skipMysql: 'mysql does not support ON CONFLICT clauses',
+  );
+
+  r.addTest(
+    'Conflict on email, target email -> update',
+    (db) async {
+      await db.multiItems
+          .insertValue(id: 1, name: 'A', email: 'a@e.com', value: 10)
+          .execute();
+
+      await db.multiItems
+          .insertValue(id: 2, name: 'B', email: 'a@e.com', value: 20)
+          .onConflict(MultiItemConflict.email)
+          .update((item, excluded, set) => set(value: excluded.value))
+          .execute();
+
+      final item = await db.multiItems
+          .where((i) => i.email.equalsValue('a@e.com'))
+          .first
+          .fetch();
+      check(item).isNotNull().id.equals(1);
+      check(item).isNotNull().value.equals(20);
+    },
+    skipMysql: 'mysql does not support ON CONFLICT clauses',
+  );
+
+  r.addTest(
+    'Conflict on both, target name, update causes email conflict -> fail',
+    (db) async {
+      await db.multiItems
+          .insertValue(id: 1, name: 'A', email: 'a@e.com', value: 10)
+          .execute();
+      await db.multiItems
+          .insertValue(id: 2, name: 'B', email: 'b@e.com', value: 10)
+          .execute();
+
+      try {
+        await db.multiItems
+            .insertValue(
+              id: 3,
+              name: 'A',
+              email: 'b@e.com',
+              value: 20,
+            ) // Conflicts on name with row 1
+            .onConflict(MultiItemConflict.name)
+            .update(
+              (item, excluded, set) =>
+                  set(value: excluded.value, email: excluded.email),
+            ) // Update causes email conflict with row 2
+            .execute();
+        fail('Expected OperationException due to email conflict on update');
+      } on OperationException {
+        // Expected
+      }
+    },
+    skipMysql: 'mysql does not support ON CONFLICT clauses',
+  );
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.g.dart
@@ -1,0 +1,452 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'upsert_multi_conflict_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [MultiConflictDatabase].
+extension MultiConflictDatabaseSchema on Database<MultiConflictDatabase> {
+  static final _$tables = [_$MultiItem._$table];
+
+  Table<MultiItem> get multiItems =>
+      $ForGeneratedCode.declareTable(this, _$MultiItem._$table);
+
+  /// Create tables defined in [MultiConflictDatabase].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [MultiConflictDatabase]. In production it's often better to
+  /// use [createMultiConflictDatabaseTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [MultiConflictDatabase].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [MultiConflictDatabase]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createMultiConflictDatabaseTables(SqlDialect dialect) =>
+    $ForGeneratedCode.createTableSchema(
+      dialect: dialect,
+      tables: MultiConflictDatabaseSchema._$tables,
+    );
+
+final class _$MultiItem extends MultiItem {
+  _$MultiItem._(this.id, this.name, this.email, this.value);
+
+  @override
+  final int id;
+
+  @override
+  final String name;
+
+  @override
+  final String email;
+
+  @override
+  final int value;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'multiItems',
+    columns: <String>['id', 'name', 'email', 'value'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[
+      ['name'],
+      ['email'],
+    ],
+    foreignKeys: [],
+    readRow: _$MultiItem._$fromDatabase,
+  );
+
+  static MultiItem? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final name = row.readString();
+    final email = row.readString();
+    final value = row.readInt();
+    if (id == null && name == null && email == null && value == null) {
+      return null;
+    }
+    return _$MultiItem._(id!, name!, email!, value!);
+  }
+
+  @override
+  String toString() =>
+      'MultiItem(id: "$id", name: "$name", email: "$email", value: "$value")';
+}
+
+/// Extension methods for table defined in [MultiItem].
+extension TableMultiItemExt on Table<MultiItem> {
+  /// Insert row into the `multiItems` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<MultiItem> insert({
+    Expr<int>? id,
+    required Expr<String> name,
+    required Expr<String> email,
+    required Expr<int> value,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id, name, email, value],
+  );
+
+  /// Insert row into the `multiItems` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<MultiItem> insertValue({
+    int? id,
+    required String name,
+    required String email,
+    required int value,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, name.asExpr, email.asExpr, value.asExpr],
+  );
+
+  /// Delete a single row from the `multiItems` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<MultiItem> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$MultiItem._$table);
+}
+
+/// Extension methods for building queries against the `multiItems` table.
+extension QueryMultiItemExt on Query<(Expr<MultiItem>,)> {
+  /// Lookup a single row in `multiItems` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<MultiItem>,)> byKey(int id) =>
+      where((multiItem) => multiItem.id.equalsValue(id)).first;
+
+  /// Update all rows in the `multiItems` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<MultiItem> update(
+    UpdateSet<MultiItem> Function(
+      Expr<MultiItem> multiItem,
+      UpdateSet<MultiItem> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<String> email,
+        Expr<int> value,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<MultiItem>(
+    this,
+    _$MultiItem._$table,
+    (multiItem) => updateBuilder(
+      multiItem,
+      ({
+        Expr<int>? id,
+        Expr<String>? name,
+        Expr<String>? email,
+        Expr<int>? value,
+      }) => $ForGeneratedCode.buildUpdate<MultiItem>([id, name, email, value]),
+    ),
+  );
+
+  /// Lookup a single row in `multiItems` table using the
+  /// `name` field
+  ///
+  /// We know that lookup by the `name` field returns
+  /// at-most one row because the [Unique] annotation in [MultiItem].
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<MultiItem>,)> byName(String name) =>
+      where((multiItem) => multiItem.name.equalsValue(name)).first;
+
+  /// Lookup a single row in `multiItems` table using the
+  /// `email` field
+  ///
+  /// We know that lookup by the `email` field returns
+  /// at-most one row because the [Unique] annotation in [MultiItem].
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<MultiItem>,)> byEmail(String email) =>
+      where((multiItem) => multiItem.email.equalsValue(email)).first;
+
+  /// Delete all rows in the `multiItems` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<MultiItem> delete() =>
+      $ForGeneratedCode.delete(this, _$MultiItem._$table);
+}
+
+/// Extension methods for building point queries against the `multiItems` table.
+extension QuerySingleMultiItemExt on QuerySingle<(Expr<MultiItem>,)> {
+  /// Update the row (if any) in the `multiItems` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<MultiItem> update(
+    UpdateSet<MultiItem> Function(
+      Expr<MultiItem> multiItem,
+      UpdateSet<MultiItem> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<String> email,
+        Expr<int> value,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<MultiItem>(
+    this,
+    _$MultiItem._$table,
+    (multiItem) => updateBuilder(
+      multiItem,
+      ({
+        Expr<int>? id,
+        Expr<String>? name,
+        Expr<String>? email,
+        Expr<int>? value,
+      }) => $ForGeneratedCode.buildUpdate<MultiItem>([id, name, email, value]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `multiItems` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<MultiItem> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$MultiItem._$table);
+}
+
+/// Extension methods for expressions on a row in the `multiItems` table.
+extension ExpressionMultiItemExt on Expr<MultiItem> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String> get email =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  Expr<int> get value =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.integer);
+}
+
+extension ExpressionNullableMultiItemExt on Expr<MultiItem?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<String?> get email =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
+
+  Expr<int?> get value =>
+      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.integer);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<MultiItem>` conflict targets for use with `.onConflict`.
+enum MultiItemConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `id`.
+  primaryKey(['id']),
+
+  /// `name` conflict.
+  ///
+  /// Due to violation of the `UNIQUE` constraint on
+  /// `name`.
+  ///
+  /// Thus, the conflicting row has matching values for these fields.
+  name(['name']),
+
+  /// `email` conflict.
+  ///
+  /// Due to violation of the `UNIQUE` constraint on
+  /// `email`.
+  ///
+  /// Thus, the conflicting row has matching values for these fields.
+  email(['email']);
+
+  const MultiItemConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleMultiItemExt on InsertSingle<MultiItem> {
+  InsertOnConflictSingle<MultiItem> onConflict(MultiItemConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleMultiItemExt
+    on InsertOnConflictSingle<MultiItem> {
+  UpsertOne<MultiItem> update(
+    UpdateSet<MultiItem> Function(
+      Expr<MultiItem> multiItem,
+      Expr<MultiItem> excluded,
+      UpdateSet<MultiItem> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<String> email,
+        Expr<int> value,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<MultiItem>(
+    this,
+    (multiItem, excluded) => updateBuilder(
+      multiItem,
+      excluded,
+      ({
+        Expr<int>? id,
+        Expr<String>? name,
+        Expr<String>? email,
+        Expr<int>? value,
+      }) => $ForGeneratedCode.buildUpdate<MultiItem>([id, name, email, value]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [MultiItem] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension MultiItemChecks on Subject<MultiItem> {
+  /// Create assertions on [MultiItem.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [MultiItem.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [MultiItem.email].
+  Subject<String> get email => has((m) => m.email, 'email');
+
+  /// Create assertions on [MultiItem.value].
+  Subject<int> get value => has((m) => m.value, 'value');
+}

--- a/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.dart
+++ b/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.dart
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'deep_extraction_test.g.dart';
+
+abstract final class ProductCatalog extends Schema {
+  Table<Product> get products;
+}
+
+@PrimaryKey(['id'])
+abstract final class Product extends Row {
+  @AutoIncrement()
+  int get id;
+
+  String get name;
+
+  JsonValue get metadata;
+}
+
+void main() {
+  final r = TestRunner<ProductCatalog>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest(
+    'Deep JSON extraction with mixed keys and indices',
+    (db) async {
+      await db.products
+          .insertValue(
+            name: 'Gadget',
+            metadata: const JsonValue({
+              'tags': ['electronics', 'new'],
+              'specs': {
+                'dimensions': [10, 20, 30],
+                'color': 'black',
+              },
+            }),
+          )
+          .execute();
+
+      final result = await db.products
+          .select(
+            (p) => (
+              p.metadata['specs']['dimensions'][1].asInt(),
+              p.metadata['tags'][0].asString(),
+            ),
+          )
+          .first
+          .fetch();
+
+      check(result).isNotNull().equals((20, 'electronics'));
+    },
+    skipMysql: 'MariaDB fails to extract array index with parameterized path',
+  );
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.g.dart
+++ b/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.g.dart
@@ -1,0 +1,362 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deep_extraction_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [ProductCatalog].
+extension ProductCatalogSchema on Database<ProductCatalog> {
+  static final _$tables = [_$Product._$table];
+
+  Table<Product> get products =>
+      $ForGeneratedCode.declareTable(this, _$Product._$table);
+
+  /// Create tables defined in [ProductCatalog].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [ProductCatalog]. In production it's often better to
+  /// use [createProductCatalogTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [ProductCatalog].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [ProductCatalog]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createProductCatalogTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: ProductCatalogSchema._$tables);
+
+final class _$Product extends Product {
+  _$Product._(this.id, this.name, this.metadata);
+
+  @override
+  final int id;
+
+  @override
+  final String name;
+
+  @override
+  final JsonValue metadata;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'products',
+    columns: <String>['id', 'name', 'metadata'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.jsonValue,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Product._$fromDatabase,
+  );
+
+  static Product? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final name = row.readString();
+    final metadata = row.readJsonValue();
+    if (id == null && name == null && metadata == null) {
+      return null;
+    }
+    return _$Product._(id!, name!, metadata!);
+  }
+
+  @override
+  String toString() =>
+      'Product(id: "$id", name: "$name", metadata: "$metadata")';
+}
+
+/// Extension methods for table defined in [Product].
+extension TableProductExt on Table<Product> {
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insert({
+    Expr<int>? id,
+    required Expr<String> name,
+    required Expr<JsonValue> metadata,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, metadata]);
+
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insertValue({
+    int? id,
+    required String name,
+    required JsonValue metadata,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, name.asExpr, metadata.asExpr],
+  );
+
+  /// Delete a single row from the `products` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Product> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
+}
+
+/// Extension methods for building queries against the `products` table.
+extension QueryProductExt on Query<(Expr<Product>,)> {
+  /// Lookup a single row in `products` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Product>,)> byKey(int id) =>
+      where((product) => product.id.equalsValue(id)).first;
+
+  /// Update all rows in the `products` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete all rows in the `products` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Product> delete() => $ForGeneratedCode.delete(this, _$Product._$table);
+}
+
+/// Extension methods for building point queries against the `products` table.
+extension QuerySingleProductExt on QuerySingle<(Expr<Product>,)> {
+  /// Update the row (if any) in the `products` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `products` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Product> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Product._$table);
+}
+
+/// Extension methods for expressions on a row in the `products` table.
+extension ExpressionProductExt on Expr<Product> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+}
+
+extension ExpressionNullableProductExt on Expr<Product?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue?> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Product>` conflict targets for use with `.onConflict`.
+enum ProductConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `id`.
+  primaryKey(['id']);
+
+  const ProductConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleProductExt on InsertSingle<Product> {
+  InsertOnConflictSingle<Product> onConflict(ProductConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleProductExt on InsertOnConflictSingle<Product> {
+  UpsertOne<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      Expr<Product> excluded,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Product>(
+    this,
+    (product, excluded) => updateBuilder(
+      product,
+      excluded,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Product] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ProductChecks on Subject<Product> {
+  /// Create assertions on [Product.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [Product.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [Product.metadata].
+  Subject<JsonValue> get metadata => has((m) => m.metadata, 'metadata');
+}

--- a/typed_sql/test/typed_sql/json/null_handling/null_handling_test.dart
+++ b/typed_sql/test/typed_sql/json/null_handling/null_handling_test.dart
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'null_handling_test.g.dart';
+
+abstract final class ProductCatalog extends Schema {
+  Table<Product> get products;
+}
+
+@PrimaryKey(['id'])
+abstract final class Product extends Row {
+  @AutoIncrement()
+  int get id;
+
+  String get name;
+
+  @DefaultValue(JsonValue({}))
+  JsonValue get metadata;
+}
+
+void main() {
+  final r = TestRunner<ProductCatalog>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('JSON null vs SQL NULL', (db) async {
+    await db.products
+        .insertValue(
+          name: 'NullGadget',
+          metadata: const JsonValue(null),
+        )
+        .execute();
+
+    final result = await db.products
+        .where((p) => p.name.equals(toExpr('NullGadget')))
+        .select(
+          (p) => (
+            p.metadata.isNull(),
+            p.metadata.asString().isNull(),
+          ),
+        )
+        .first
+        .fetch();
+
+    check(result).isNotNull().equals((false, true));
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/json/null_handling/null_handling_test.g.dart
+++ b/typed_sql/test/typed_sql/json/null_handling/null_handling_test.g.dart
@@ -1,0 +1,362 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'null_handling_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [ProductCatalog].
+extension ProductCatalogSchema on Database<ProductCatalog> {
+  static final _$tables = [_$Product._$table];
+
+  Table<Product> get products =>
+      $ForGeneratedCode.declareTable(this, _$Product._$table);
+
+  /// Create tables defined in [ProductCatalog].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [ProductCatalog]. In production it's often better to
+  /// use [createProductCatalogTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [ProductCatalog].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [ProductCatalog]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createProductCatalogTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: ProductCatalogSchema._$tables);
+
+final class _$Product extends Product {
+  _$Product._(this.id, this.name, this.metadata);
+
+  @override
+  final int id;
+
+  @override
+  final String name;
+
+  @override
+  final JsonValue metadata;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'products',
+    columns: <String>['id', 'name', 'metadata'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.jsonValue,
+        isNotNull: true,
+        defaultValue: (kind: 'raw', value: const JsonValue({})),
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['id'],
+    unique: <List<String>>[],
+    foreignKeys: [],
+    readRow: _$Product._$fromDatabase,
+  );
+
+  static Product? _$fromDatabase(RowReader row) {
+    final id = row.readInt();
+    final name = row.readString();
+    final metadata = row.readJsonValue();
+    if (id == null && name == null && metadata == null) {
+      return null;
+    }
+    return _$Product._(id!, name!, metadata!);
+  }
+
+  @override
+  String toString() =>
+      'Product(id: "$id", name: "$name", metadata: "$metadata")';
+}
+
+/// Extension methods for table defined in [Product].
+extension TableProductExt on Table<Product> {
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insert({
+    Expr<int>? id,
+    required Expr<String> name,
+    Expr<JsonValue>? metadata,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, metadata]);
+
+  /// Insert row into the `products` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Product> insertValue({
+    int? id,
+    required String name,
+    JsonValue? metadata,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [id?.asExpr, name.asExpr, metadata?.asExpr],
+  );
+
+  /// Delete a single row from the `products` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Product> delete(int id) =>
+      $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
+}
+
+/// Extension methods for building queries against the `products` table.
+extension QueryProductExt on Query<(Expr<Product>,)> {
+  /// Lookup a single row in `products` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Product>,)> byKey(int id) =>
+      where((product) => product.id.equalsValue(id)).first;
+
+  /// Update all rows in the `products` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete all rows in the `products` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Product> delete() => $ForGeneratedCode.delete(this, _$Product._$table);
+}
+
+/// Extension methods for building point queries against the `products` table.
+extension QuerySingleProductExt on QuerySingle<(Expr<Product>,)> {
+  /// Update the row (if any) in the `products` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Product>(
+    this,
+    _$Product._$table,
+    (product) => updateBuilder(
+      product,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `products` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Product> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Product._$table);
+}
+
+/// Extension methods for expressions on a row in the `products` table.
+extension ExpressionProductExt on Expr<Product> {
+  Expr<int> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+}
+
+extension ExpressionNullableProductExt on Expr<Product?> {
+  Expr<int?> get id =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get name =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<JsonValue?> get metadata =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.jsonValue);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => id.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Product>` conflict targets for use with `.onConflict`.
+enum ProductConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `id`.
+  primaryKey(['id']);
+
+  const ProductConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleProductExt on InsertSingle<Product> {
+  InsertOnConflictSingle<Product> onConflict(ProductConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleProductExt on InsertOnConflictSingle<Product> {
+  UpsertOne<Product> update(
+    UpdateSet<Product> Function(
+      Expr<Product> product,
+      Expr<Product> excluded,
+      UpdateSet<Product> Function({
+        Expr<int> id,
+        Expr<String> name,
+        Expr<JsonValue> metadata,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Product>(
+    this,
+    (product, excluded) => updateBuilder(
+      product,
+      excluded,
+      ({Expr<int>? id, Expr<String>? name, Expr<JsonValue>? metadata}) =>
+          $ForGeneratedCode.buildUpdate<Product>([id, name, metadata]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Product] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension ProductChecks on Subject<Product> {
+  /// Create assertions on [Product.id].
+  Subject<int> get id => has((m) => m.id, 'id');
+
+  /// Create assertions on [Product.name].
+  Subject<String> get name => has((m) => m.name, 'name');
+
+  /// Create assertions on [Product.metadata].
+  Subject<JsonValue> get metadata => has((m) => m.metadata, 'metadata');
+}

--- a/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.dart
+++ b/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'nested_basic_test.g.dart';
+
+abstract final class BankVault extends Schema {
+  Table<Account> get accounts;
+}
+
+@PrimaryKey(['accountId'])
+abstract final class Account extends Row {
+  @AutoIncrement()
+  int get accountId;
+
+  @Unique.field()
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get accountNumber;
+
+  @DefaultValue(0.0)
+  double get balance;
+}
+
+void main() {
+  final r = TestRunner<BankVault>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('Basic nested transaction (savepoint) rollback', (db) async {
+    await db.accounts
+        .insertValue(accountNumber: '0001', balance: 100.0)
+        .execute();
+
+    await db.transact(() async {
+      // Update in outer transaction
+      await db.accounts
+          .byAccountNumber('0001')
+          .update((a, set) => set(balance: toExpr(200.0)))
+          .execute();
+
+      try {
+        await db.transact(() async {
+          // Update in inner transaction
+          await db.accounts
+              .byAccountNumber('0001')
+              .update((a, set) => set(balance: toExpr(300.0)))
+              .execute();
+
+          // Abort inner transaction
+          throw Exception('Abort inner');
+        });
+      } on TransactionAbortedException {
+        // Expected
+      }
+
+      // Outer transaction should still see its own update (200), not inner (300)
+      final item = await db.accounts.byAccountNumber('0001').fetch();
+      check(item).isNotNull().balance.equals(200.0);
+    });
+
+    // After commit, should still be 200
+    final item = await db.accounts.byAccountNumber('0001').fetch();
+    check(item).isNotNull().balance.equals(200.0);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.g.dart
@@ -1,0 +1,411 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nested_basic_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [BankVault].
+extension BankVaultSchema on Database<BankVault> {
+  static final _$tables = [_$Account._$table];
+
+  Table<Account> get accounts =>
+      $ForGeneratedCode.declareTable(this, _$Account._$table);
+
+  /// Create tables defined in [BankVault].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [BankVault]. In production it's often better to
+  /// use [createBankVaultTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [BankVault].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [BankVault]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createBankVaultTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: BankVaultSchema._$tables);
+
+final class _$Account extends Account {
+  _$Account._(this.accountId, this.accountNumber, this.balance);
+
+  @override
+  final int accountId;
+
+  @override
+  final String accountNumber;
+
+  @override
+  final double balance;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'accounts',
+    columns: <String>['accountId', 'accountNumber', 'balance'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.real,
+        isNotNull: true,
+        defaultValue: (kind: 'raw', value: 0.0),
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['accountId'],
+    unique: <List<String>>[
+      ['accountNumber'],
+    ],
+    foreignKeys: [],
+    readRow: _$Account._$fromDatabase,
+  );
+
+  static Account? _$fromDatabase(RowReader row) {
+    final accountId = row.readInt();
+    final accountNumber = row.readString();
+    final balance = row.readDouble();
+    if (accountId == null && accountNumber == null && balance == null) {
+      return null;
+    }
+    return _$Account._(accountId!, accountNumber!, balance!);
+  }
+
+  @override
+  String toString() =>
+      'Account(accountId: "$accountId", accountNumber: "$accountNumber", balance: "$balance")';
+}
+
+/// Extension methods for table defined in [Account].
+extension TableAccountExt on Table<Account> {
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insert({
+    Expr<int>? accountId,
+    required Expr<String> accountNumber,
+    Expr<double>? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId, accountNumber, balance],
+  );
+
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
+  /// Delete a single row from the `accounts` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Account> delete(int accountId) =>
+      $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
+}
+
+/// Extension methods for building queries against the `accounts` table.
+extension QueryAccountExt on Query<(Expr<Account>,)> {
+  /// Lookup a single row in `accounts` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
+      where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Update all rows in the `accounts` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Account>(
+    this,
+    _$Account._$table,
+    (account) => updateBuilder(
+      account,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+
+  /// Lookup a single row in `accounts` table using the
+  /// `accountNumber` field
+  ///
+  /// We know that lookup by the `accountNumber` field returns
+  /// at-most one row because the [Unique] annotation in [Account].
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Account>,)> byAccountNumber(String accountNumber) => where(
+    (account) => account.accountNumber.equalsValue(accountNumber),
+  ).first;
+
+  /// Delete all rows in the `accounts` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Account> delete() => $ForGeneratedCode.delete(this, _$Account._$table);
+}
+
+/// Extension methods for building point queries against the `accounts` table.
+extension QuerySingleAccountExt on QuerySingle<(Expr<Account>,)> {
+  /// Update the row (if any) in the `accounts` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Account>(
+    this,
+    _$Account._$table,
+    (account) => updateBuilder(
+      account,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `accounts` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Account> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Account._$table);
+}
+
+/// Extension methods for expressions on a row in the `accounts` table.
+extension ExpressionAccountExt on Expr<Account> {
+  Expr<int> get accountId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get accountNumber =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<double> get balance =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.real);
+}
+
+extension ExpressionNullableAccountExt on Expr<Account?> {
+  Expr<int?> get accountId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get accountNumber =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<double?> get balance =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.real);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => accountId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Account>` conflict targets for use with `.onConflict`.
+enum AccountConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `accountId`.
+  primaryKey(['accountId']),
+
+  /// `accountNumber` conflict.
+  ///
+  /// Due to violation of the `UNIQUE` constraint on
+  /// `accountNumber`.
+  ///
+  /// Thus, the conflicting row has matching values for these fields.
+  accountNumber(['accountNumber']);
+
+  const AccountConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleAccountExt on InsertSingle<Account> {
+  InsertOnConflictSingle<Account> onConflict(AccountConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleAccountExt on InsertOnConflictSingle<Account> {
+  UpsertOne<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      Expr<Account> excluded,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Account>(
+    this,
+    (account, excluded) => updateBuilder(
+      account,
+      excluded,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Account] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension AccountChecks on Subject<Account> {
+  /// Create assertions on [Account.accountId].
+  Subject<int> get accountId => has((m) => m.accountId, 'accountId');
+
+  /// Create assertions on [Account.accountNumber].
+  Subject<String> get accountNumber =>
+      has((m) => m.accountNumber, 'accountNumber');
+
+  /// Create assertions on [Account.balance].
+  Subject<double> get balance => has((m) => m.balance, 'balance');
+}

--- a/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.dart
+++ b/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.dart
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+import '../../testrunner.dart';
+
+part 'nested_complex_test.g.dart';
+
+abstract final class BankVault extends Schema {
+  Table<Account> get accounts;
+}
+
+@PrimaryKey(['accountId'])
+abstract final class Account extends Row {
+  @AutoIncrement()
+  int get accountId;
+
+  @Unique.field()
+  @SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get accountNumber;
+
+  @DefaultValue(0.0)
+  double get balance;
+}
+
+void main() {
+  final r = TestRunner<BankVault>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  r.addTest('Complex nested transaction with partial rollback', (db) async {
+    await db.accounts
+        .insertValue(accountNumber: '0001', balance: 100.0)
+        .execute();
+    await db.accounts
+        .insertValue(accountNumber: '0002', balance: 200.0)
+        .execute();
+
+    await db.transact(() async {
+      await db.accounts
+          .byAccountNumber('0001')
+          .update((a, set) => set(balance: toExpr(150.0)))
+          .execute();
+
+      await db.transact(() async {
+        await db.accounts
+            .byAccountNumber('0002')
+            .update((a, set) => set(balance: toExpr(250.0)))
+            .execute();
+
+        try {
+          await db.transact(() async {
+            await db.accounts
+                .byAccountNumber('0001')
+                .update((a, set) => set(balance: toExpr(999.0)))
+                .execute();
+            throw Exception('Abort level 3');
+          });
+        } on TransactionAbortedException {
+          // Expected
+        }
+
+        // Level 2 should see its own update (250) and level 1 update (150), but NOT level 3 (999)
+        final a1 = await db.accounts.byAccountNumber('0001').fetch();
+        check(a1).isNotNull().balance.equals(150.0);
+
+        final a2 = await db.accounts.byAccountNumber('0002').fetch();
+        check(a2).isNotNull().balance.equals(250.0);
+      });
+
+      // Level 1 should see its own update (150) and level 2 update (250) because level 2 committed!
+      final a1 = await db.accounts.byAccountNumber('0001').fetch();
+      check(a1).isNotNull().balance.equals(150.0);
+
+      final a2 = await db.accounts.byAccountNumber('0002').fetch();
+      check(a2).isNotNull().balance.equals(250.0);
+    });
+
+    // After outer commit, all changes from level 1 and level 2 should be visible!
+    final a1 = await db.accounts.byAccountNumber('0001').fetch();
+    check(a1).isNotNull().balance.equals(150.0);
+
+    final a2 = await db.accounts.byAccountNumber('0002').fetch();
+    check(a2).isNotNull().balance.equals(250.0);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.g.dart
@@ -1,0 +1,411 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nested_complex_test.dart';
+
+// **************************************************************************
+// Generator: _TypedSqlBuilder
+// **************************************************************************
+
+/// Extension methods for a [Database] operating on [BankVault].
+extension BankVaultSchema on Database<BankVault> {
+  static final _$tables = [_$Account._$table];
+
+  Table<Account> get accounts =>
+      $ForGeneratedCode.declareTable(this, _$Account._$table);
+
+  /// Create tables defined in [BankVault].
+  ///
+  /// Calling this on an empty database will create the tables
+  /// defined in [BankVault]. In production it's often better to
+  /// use [createBankVaultTables] and manage migrations using
+  /// external tools.
+  ///
+  /// This method is mostly useful for testing.
+  ///
+  /// > [!WARNING]
+  /// > If the database is **not empty** behavior is undefined, most
+  /// > likely this operation will fail.
+  Future<void> createTables() async =>
+      $ForGeneratedCode.createTables(context: this, tables: _$tables);
+}
+
+/// Get SQL [DDL statements][1] for tables defined in [BankVault].
+///
+/// This returns a SQL script with multiple DDL statements separated by `;`
+/// using the specified [dialect].
+///
+/// Executing these statements in an empty database will create the tables
+/// defined in [BankVault]. In practice, this method is often used for
+/// printing the DDL statements, such that migrations can be managed by
+/// external tools.
+///
+/// [1]: https://en.wikipedia.org/wiki/Data_definition_language
+String createBankVaultTables(SqlDialect dialect) => $ForGeneratedCode
+    .createTableSchema(dialect: dialect, tables: BankVaultSchema._$tables);
+
+final class _$Account extends Account {
+  _$Account._(this.accountId, this.accountNumber, this.balance);
+
+  @override
+  final int accountId;
+
+  @override
+  final String accountNumber;
+
+  @override
+  final double balance;
+
+  static final _$table = $ForGeneratedCode.tableDefinition(
+    tableName: 'accounts',
+    columns: <String>['accountId', 'accountNumber', 'balance'],
+    columnInfo: [
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.integer,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: true,
+        overrides: [],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.text,
+        isNotNull: true,
+        defaultValue: null,
+        autoIncrement: false,
+        overrides: [
+          const SqlOverride(dialect: 'mysql', columnType: 'VARCHAR(255)'),
+        ],
+      ),
+      $ForGeneratedCode.columnDefinition(
+        type: $ForGeneratedCode.real,
+        isNotNull: true,
+        defaultValue: (kind: 'raw', value: 0.0),
+        autoIncrement: false,
+        overrides: [],
+      ),
+    ],
+    primaryKey: <String>['accountId'],
+    unique: <List<String>>[
+      ['accountNumber'],
+    ],
+    foreignKeys: [],
+    readRow: _$Account._$fromDatabase,
+  );
+
+  static Account? _$fromDatabase(RowReader row) {
+    final accountId = row.readInt();
+    final accountNumber = row.readString();
+    final balance = row.readDouble();
+    if (accountId == null && accountNumber == null && balance == null) {
+      return null;
+    }
+    return _$Account._(accountId!, accountNumber!, balance!);
+  }
+
+  @override
+  String toString() =>
+      'Account(accountId: "$accountId", accountNumber: "$accountNumber", balance: "$balance")';
+}
+
+/// Extension methods for table defined in [Account].
+extension TableAccountExt on Table<Account> {
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insert({
+    Expr<int>? accountId,
+    required Expr<String> accountNumber,
+    Expr<double>? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId, accountNumber, balance],
+  );
+
+  /// Insert row into the `accounts` table.
+  ///
+  /// Returns a [InsertSingle] statement on which `.execute` must be
+  /// called for the row to be inserted.
+  InsertSingle<Account> insertValue({
+    int? accountId,
+    required String accountNumber,
+    double? balance,
+  }) => $ForGeneratedCode.insertInto(
+    table: this,
+    values: [accountId?.asExpr, accountNumber.asExpr, balance?.asExpr],
+  );
+
+  /// Delete a single row from the `accounts` table, specified by
+  /// _primary key_.
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be
+  /// called for the row to be deleted.
+  ///
+  /// To delete multiple rows, using `.where()` to filter which rows
+  /// should be deleted. If you wish to delete all rows, use
+  /// `.where((_) => toExpr(true)).delete()`.
+  DeleteSingle<Account> delete(int accountId) =>
+      $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
+}
+
+/// Extension methods for building queries against the `accounts` table.
+extension QueryAccountExt on Query<(Expr<Account>,)> {
+  /// Lookup a single row in `accounts` table using the _primary key_.
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
+      where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Update all rows in the `accounts` table matching this [Query].
+  ///
+  /// The changes to be applied to each row matching this [Query] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [Update] statement on which `.execute()` must be called
+  /// for the rows to be updated.
+  ///
+  /// **Example:** decrementing `1` from the `value` field for each row
+  /// where `value > 0`.
+  /// ```dart
+  /// await db.mytable
+  ///   .where((row) => row.value > toExpr(0))
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  Update<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.update<Account>(
+    this,
+    _$Account._$table,
+    (account) => updateBuilder(
+      account,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+
+  /// Lookup a single row in `accounts` table using the
+  /// `accountNumber` field
+  ///
+  /// We know that lookup by the `accountNumber` field returns
+  /// at-most one row because the [Unique] annotation in [Account].
+  ///
+  /// Returns a [QuerySingle] object, which returns at-most one row,
+  /// when `.fetch()` is called.
+  QuerySingle<(Expr<Account>,)> byAccountNumber(String accountNumber) => where(
+    (account) => account.accountNumber.equalsValue(accountNumber),
+  ).first;
+
+  /// Delete all rows in the `accounts` table matching this [Query].
+  ///
+  /// Returns a [Delete] statement on which `.execute()` must be called
+  /// for the rows to be deleted.
+  Delete<Account> delete() => $ForGeneratedCode.delete(this, _$Account._$table);
+}
+
+/// Extension methods for building point queries against the `accounts` table.
+extension QuerySingleAccountExt on QuerySingle<(Expr<Account>,)> {
+  /// Update the row (if any) in the `accounts` table matching this
+  /// [QuerySingle].
+  ///
+  /// The changes to be applied to the row matching this [QuerySingle] are
+  /// defined using the [updateBuilder], which is given an [Expr]
+  /// representation of the row being updated and a `set` function to
+  /// specify which fields should be updated. The result of the `set`
+  /// function should always be returned from the `updateBuilder`.
+  ///
+  /// Returns an [UpdateSingle] statement on which `.execute()` must be
+  /// called for the row to be updated. The resulting statement will
+  /// **not** fail, if there are no rows matching this query exists.
+  ///
+  /// **Example:** decrementing `1` from the `value` field the row with
+  /// `id = 1`.
+  /// ```dart
+  /// await db.mytable
+  ///   .byKey(1)
+  ///   .update((row, set) => set(
+  ///     value: row.value - toExpr(1),
+  ///   ))
+  ///   .execute();
+  /// ```
+  ///
+  /// > [!WARNING]
+  /// > The `updateBuilder` callback does not make the update, it builds
+  /// > the expressions for updating the rows. You should **never** invoke
+  /// > the `set` function more than once, and the result should always
+  /// > be returned immediately.
+  UpdateSingle<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateSingle<Account>(
+    this,
+    _$Account._$table,
+    (account) => updateBuilder(
+      account,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+
+  /// Delete the row (if any) in the `accounts` table matching this [QuerySingle].
+  ///
+  /// Returns a [DeleteSingle] statement on which `.execute()` must be called
+  /// for the row to be deleted. The resulting statement will **not**
+  /// fail, if there are no rows matching this query exists.
+  DeleteSingle<Account> delete() =>
+      $ForGeneratedCode.deleteSingle(this, _$Account._$table);
+}
+
+/// Extension methods for expressions on a row in the `accounts` table.
+extension ExpressionAccountExt on Expr<Account> {
+  Expr<int> get accountId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String> get accountNumber =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<double> get balance =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.real);
+}
+
+extension ExpressionNullableAccountExt on Expr<Account?> {
+  Expr<int?> get accountId =>
+      $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
+
+  Expr<String?> get accountNumber =>
+      $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
+
+  Expr<double?> get balance =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.real);
+
+  /// Check if the row is not `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNotNull() => accountId.isNotNull();
+
+  /// Check if the row is `NULL`.
+  ///
+  /// This will check if _primary key_ fields in this row are `NULL`.
+  ///
+  /// If this is a reference lookup by subquery it might be more efficient
+  /// to check if the referencing field is `NULL`.
+  Expr<bool> isNull() => isNotNull().not();
+}
+
+/// `Table<Account>` conflict targets for use with `.onConflict`.
+enum AccountConflict {
+  /// Conflict with an existing row that has a matching primary key.
+  ///
+  /// Thus, the other row has matching values for:
+  /// `accountId`.
+  primaryKey(['accountId']),
+
+  /// `accountNumber` conflict.
+  ///
+  /// Due to violation of the `UNIQUE` constraint on
+  /// `accountNumber`.
+  ///
+  /// Thus, the conflicting row has matching values for these fields.
+  accountNumber(['accountNumber']);
+
+  const AccountConflict(this._fields);
+
+  final List<String> _fields;
+}
+
+extension InsertSingleAccountExt on InsertSingle<Account> {
+  InsertOnConflictSingle<Account> onConflict(AccountConflict target) =>
+      $ForGeneratedCode.insertSingleOnConflict(this, target._fields);
+}
+
+extension InsertOnConflictSingleAccountExt on InsertOnConflictSingle<Account> {
+  UpsertOne<Account> update(
+    UpdateSet<Account> Function(
+      Expr<Account> account,
+      Expr<Account> excluded,
+      UpdateSet<Account> Function({
+        Expr<int> accountId,
+        Expr<String> accountNumber,
+        Expr<double> balance,
+      })
+      set,
+    )
+    updateBuilder,
+  ) => $ForGeneratedCode.updateOnConflict<Account>(
+    this,
+    (account, excluded) => updateBuilder(
+      account,
+      excluded,
+      ({
+        Expr<int>? accountId,
+        Expr<String>? accountNumber,
+        Expr<double>? balance,
+      }) => $ForGeneratedCode.buildUpdate<Account>([
+        accountId,
+        accountNumber,
+        balance,
+      ]),
+    ),
+  );
+}
+
+/// Extension methods for assertions on [Account] using
+/// [`package:checks`][1].
+///
+/// [1]: https://pub.dev/packages/checks
+extension AccountChecks on Subject<Account> {
+  /// Create assertions on [Account.accountId].
+  Subject<int> get accountId => has((m) => m.accountId, 'accountId');
+
+  /// Create assertions on [Account.accountNumber].
+  Subject<String> get accountNumber =>
+      has((m) => m.accountNumber, 'accountNumber');
+
+  /// Create assertions on [Account.balance].
+  Subject<double> get balance => has((m) => m.balance, 'balance');
+}


### PR DESCRIPTION
This change has some impact on what is actually possible, notably postgres will refuse some complex group-by queries if we have parameters in the expression here. So I figured we better not.

```diff
-    return 'JSON_EXTRACT(${expr(root)}, ${context.addParameter(path)})';
+    return 'JSON_EXTRACT(${expr(root)}, ${_escapeStringLiteral(path)})';
```

Granted group by something you've extracted from a JSON object is also a bit sketchy to begin with. But removing a limitation is always nice, and the way we've made the expression graph you cannot extract anything using a generic Expr, only using literal string or int (for list).