### PR TITLE
Fix equality helpers + reorder foreign key equals expressions.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,18 +309,18 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_serializable:
     dependency: transitive
     description:
       name: json_serializable
-      sha256: "2c15e78e1cc6e62aadecf59f81566fd56829713d96a8c4177699e2b2e17f20db"
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.2"
+    version: "6.14.0"
   lints:
     dependency: "direct dev"
     description:
@@ -421,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: postgres
-      sha256: "3af8a28b89fef68ee5b26b4fd27254d5a286389e9c7fb6293a5f46e30490f800"
+      sha256: fe4a19a69fad564efa8ced72d58b14e86d12a548f5f0a511b377089bf3b592ed
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.10"
+    version: "3.5.11"
   pub_semver:
     dependency: transitive
     description:

--- a/typed_sql/CHANGELOG.md
+++ b/typed_sql/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.11
+ * Fix equality helpers + reorder foreign key equals expressions.
+
 ## 0.1.10
  * Introduce `.insertValue` which automatically wraps with `toExpr()`, but is
    unfortunately unable to insert _default value_ for nullable fields that

--- a/typed_sql/lib/src/codegen/build_code.dart
+++ b/typed_sql/lib/src/codegen/build_code.dart
@@ -1014,7 +1014,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
                 _\$${fk.referencedTable.rowClass.name}._\$table
               ).where(
                 (r) =>
-                  ${fk.fields.mapIndexed((i, f) => 'r.$f.equals(${fk.foreignKey[i].name})').join(' & ')}
+                  ${fk.fields.mapIndexed((i, f) => _pkAndFkEqualsExpr('r.$f', fk.foreignKey[i].name, fk.foreignKey[i].isNullable)).join(' & ')}
               ).$firstAsNotNull
             '''),
           );
@@ -1184,7 +1184,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
                   ..lambda = true
                   ..body = Code('''
                   on((a, b) =>
-                    ${ref.fk.fields.mapIndexed((i, f) => 'a.$f.equals(b.${ref.fk.foreignKey[i].name})').join(' & ')}
+                    ${ref.fk.fields.mapIndexed((i, f) => _pkAndFkEqualsExpr('a.$f', 'b.${ref.fk.foreignKey[i].name}', ref.fk.foreignKey[i].isNullable)).join(' & ')}
                   )
                 '''),
               ),
@@ -1202,7 +1202,7 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
                   ..lambda = true
                   ..body = Code('''
                 on((a, b) =>
-                  ${fk.fields.mapIndexed((i, f) => 'b.$f.equals(a.${fk.foreignKey[i].name})').join(' & ')}
+                  ${fk.fields.mapIndexed((i, f) => _pkAndFkEqualsExpr('b.$f', 'a.${fk.foreignKey[i].name}', fk.foreignKey[i].isNullable)).join(' & ')}
                 )
               '''),
               );
@@ -1622,6 +1622,11 @@ Iterable<Spec> buildRecord(ParsedRecord record) sync* {
           '''),
     ))*/
 }
+
+/// Generate `pkExpr.equals(fkExpr)` or `fkExpr.equals(pkExpr)` depending on
+/// whether the FK field is nullable (the known nullable field must be the first).
+String _pkAndFkEqualsExpr(String pkExpr, String fkExpr, bool isFkNullable) =>
+    isFkNullable ? '$fkExpr.equals($pkExpr)' : '$pkExpr.equals($fkExpr)';
 
 extension on ParsedTable {
   String get sqlName {

--- a/typed_sql/lib/src/typed_sql.expr_ext.dart
+++ b/typed_sql/lib/src/typed_sql.expr_ext.dart
@@ -195,19 +195,19 @@ extension ExpressionNullableNum<T extends num> on Expr<T?> {
   ///  * [isNotDistinctFrom], to get `NULL` equivalent to `NULL`, or,
   ///  * [equalsUnlessNull], to explicitely get the SQL `=` semantics.
   /// {@endtemplate}
-  Expr<bool> equals(Expr<T> other) =>
+  Expr<bool> equals(Expr<T?> other) =>
       ExpressionEquals(this, other).orElseValue(false);
 
   /// {@macro equals}
-  Expr<bool> equalsValue(T other) => equals(toExpr(other));
+  Expr<bool> equalsValue(T? other) => equals(toExpr(other));
 
   /// {@template notEquals}
   /// Compare this expression to [other] using `<>` in SQL.
   /// {@endtemplate}
-  Expr<bool> notEquals(Expr<T> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<T?> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(T other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(T? other) => notEquals(toExpr(other));
 
   /// {@template isNotDistinctFrom}
   /// Compare this expression to [other] using `IS NOT DISTINCT FROM`.
@@ -253,17 +253,17 @@ extension ExpressionNullableString on Expr<String?> {
   Expr<String> orElseValue(String value) => orElse(toExpr(value));
 
   /// {@macro equals}
-  Expr<bool> equals(Expr<String> other) =>
+  Expr<bool> equals(Expr<String?> other) =>
       ExpressionEquals(this, other).orElseValue(false);
 
   /// {@macro equals}
-  Expr<bool> equalsValue(String other) => equals(toExpr(other));
+  Expr<bool> equalsValue(String? other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<String> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<String?> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(String other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(String? other) => notEquals(toExpr(other));
 
   /// {@macro isNotDistinctFrom}
   Expr<bool> isNotDistinctFrom(Expr<String?> other) =>
@@ -289,17 +289,17 @@ extension ExpressionNullableBool on Expr<bool?> {
   Expr<bool> orElseValue(bool value) => orElse(toExpr(value));
 
   /// {@macro equals}
-  Expr<bool> equals(Expr<bool> other) =>
+  Expr<bool> equals(Expr<bool?> other) =>
       ExpressionEquals(this, other).orElseValue(false);
 
   /// {@macro equals}
-  Expr<bool> equalsValue(bool other) => equals(toExpr(other));
+  Expr<bool> equalsValue(bool? other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<bool> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<bool?> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(bool other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(bool? other) => notEquals(toExpr(other));
 
   /// {@macro isNotDistinctFrom}
   Expr<bool> isNotDistinctFrom(Expr<bool?> other) =>
@@ -334,17 +334,17 @@ extension ExpressionNullableDateTime on Expr<DateTime?> {
   Expr<DateTime> orElseValue(DateTime value) => orElse(toExpr(value));
 
   /// {@macro equals}
-  Expr<bool> equals(Expr<DateTime> other) =>
+  Expr<bool> equals(Expr<DateTime?> other) =>
       ExpressionEquals(this, other).orElseValue(false);
 
   /// {@macro equals}
-  Expr<bool> equalsValue(DateTime other) => equals(toExpr(other));
+  Expr<bool> equalsValue(DateTime? other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<DateTime> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<DateTime?> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(DateTime other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(DateTime? other) => notEquals(toExpr(other));
 
   /// {@macro isNotDistinctFrom}
   Expr<bool> isNotDistinctFrom(Expr<DateTime?> other) =>
@@ -371,17 +371,17 @@ extension ExpressionNullableUint8List on Expr<Uint8List?> {
   Expr<Uint8List> orElseValue(Uint8List value) => orElse(toExpr(value));
 
   /// {@macro equals}
-  Expr<bool> equals(Expr<Uint8List> other) =>
+  Expr<bool> equals(Expr<Uint8List?> other) =>
       ExpressionEquals(this, other).orElseValue(false);
 
   /// {@macro equals}
-  Expr<bool> equalsValue(Uint8List other) => equals(toExpr(other));
+  Expr<bool> equalsValue(Uint8List? other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<Uint8List> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<Uint8List?> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(Uint8List other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(Uint8List? other) => notEquals(toExpr(other));
 
   /// {@macro isNotDistinctFrom}
   Expr<bool> isNotDistinctFrom(Expr<Uint8List?> other) =>
@@ -598,17 +598,17 @@ extension ExpressionNullableJsonValue on Expr<JsonValue?> {
 /// Extension methods for [bool] expressions.
 extension ExpressionBool on Expr<bool> {
   /// {@macro equals}
-  Expr<bool> equals(Expr<bool?> other) =>
-      ExpressionEquals(this, other).orElseValue(false);
+  Expr<bool> equals(Expr<bool> other) =>
+      ExpressionEquals(this, other).asNotNull();
 
   /// {@macro equals}
-  Expr<bool> equalsValue(bool? other) => equals(toExpr(other));
+  Expr<bool> equalsValue(bool other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<bool?> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<bool> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(bool? other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(bool other) => notEquals(toExpr(other));
 
   /// {@macro isNull}
   ///
@@ -729,17 +729,17 @@ extension ExpressionBool on Expr<bool> {
 /// Extension methods for [String] expressions.
 extension ExpressionString on Expr<String> {
   /// {@macro equals}
-  Expr<bool> equals(Expr<String?> other) =>
-      ExpressionEquals(this, other).orElseValue(false);
+  Expr<bool> equals(Expr<String> other) =>
+      ExpressionEquals(this, other).asNotNull();
 
   /// {@macro equals}
-  Expr<bool> equalsValue(String? other) => equals(toExpr(other));
+  Expr<bool> equalsValue(String other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<String?> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<String> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(String? other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(String other) => notEquals(toExpr(other));
 
   /// {@macro isNull}
   ///
@@ -1142,17 +1142,16 @@ extension ExpressionDouble on Expr<double> {
 /// Extension methods for [int] and [double] expressions.
 extension ExpressionNum<T extends num> on Expr<T> {
   /// {@macro equals}
-  Expr<bool> equals(Expr<T?> other) =>
-      ExpressionEquals(this, other).orElseValue(false);
+  Expr<bool> equals(Expr<T> other) => ExpressionEquals(this, other).asNotNull();
 
   /// {@macro equals}
-  Expr<bool> equalsValue(T? other) => equals(toExpr(other));
+  Expr<bool> equalsValue(T other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<T?> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<T> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(T? other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(T other) => notEquals(toExpr(other));
 
   /// {@macro isNull}
   ///
@@ -1230,17 +1229,17 @@ extension ExpressionNum<T extends num> on Expr<T> {
 /// Extension methods for [DateTime] expressions.
 extension ExpressionDateTime on Expr<DateTime> {
   /// {@macro equals}
-  Expr<bool> equals(Expr<DateTime?> other) =>
-      ExpressionEquals(this, other).orElseValue(false);
+  Expr<bool> equals(Expr<DateTime> other) =>
+      ExpressionEquals(this, other).asNotNull();
 
   /// {@macro equals}
-  Expr<bool> equalsValue(DateTime? other) => equals(toExpr(other));
+  Expr<bool> equalsValue(DateTime other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<DateTime?> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<DateTime> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(DateTime? other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(DateTime other) => notEquals(toExpr(other));
 
   /// {@macro isNull}
   ///
@@ -1320,17 +1319,17 @@ extension ExpressionDateTime on Expr<DateTime> {
 /// Extension methods for [Uint8List] expressions.
 extension ExpressionUint8List on Expr<Uint8List> {
   /// {@macro equals}
-  Expr<bool> equals(Expr<Uint8List?> other) =>
-      ExpressionEquals(this, other).orElseValue(false);
+  Expr<bool> equals(Expr<Uint8List> other) =>
+      ExpressionEquals(this, other).asNotNull();
 
   /// {@macro equals}
-  Expr<bool> equalsValue(Uint8List? other) => equals(toExpr(other));
+  Expr<bool> equalsValue(Uint8List other) => equals(toExpr(other));
 
   /// {@macro notEquals}
-  Expr<bool> notEquals(Expr<Uint8List?> other) => equals(other).not();
+  Expr<bool> notEquals(Expr<Uint8List> other) => equals(other).not();
 
   /// {@macro notEquals}
-  Expr<bool> notEqualsValue(Uint8List? other) => notEquals(toExpr(other));
+  Expr<bool> notEqualsValue(Uint8List other) => notEquals(toExpr(other));
 
   /// {@macro isNull}
   ///

--- a/typed_sql/pubspec.yaml
+++ b/typed_sql/pubspec.yaml
@@ -1,5 +1,5 @@
 name: typed_sql
-version: 0.1.10
+version: 0.1.11
 description: Package for doing SQL with some type safety.
 homepage: https://github.com/google/dart-neats/tree/master/typed_sql
 repository: https://github.com/google/dart-neats.git

--- a/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
+++ b/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
@@ -366,7 +366,7 @@ extension ExpressionAuthorExt on Expr<Author> {
   /// is equal to [favoriteBookId], if any.
   Expr<Book?> get favoriteBook => $ForGeneratedCode
       .subqueryTable(_$Book._$table)
-      .where((r) => r.bookId.equals(favoriteBookId))
+      .where((r) => favoriteBookId.equals(r.bookId))
       .first;
 }
 
@@ -454,13 +454,13 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author>, Expr<Book>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author>, Expr<Book>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -474,13 +474,13 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author>, Expr<Book?>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author>, Expr<Book?>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -494,13 +494,13 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author?>, Expr<Book>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author?>, Expr<Book>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -1081,7 +1081,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [editorId], if any.
   Expr<Author?> get editor => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(editorId))
+      .where((r) => editorId.equals(r.authorId))
       .first;
 }
 
@@ -1165,7 +1165,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book>, Expr<Author>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1177,7 +1177,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -1185,7 +1185,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book>, Expr<Author?>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1197,7 +1197,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -1205,7 +1205,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book?>, Expr<Author>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1217,7 +1217,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/example/company/company_test.g.dart
+++ b/typed_sql/test/typed_sql/example/company/company_test.g.dart
@@ -381,7 +381,7 @@ extension InnerJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department>, Expr<Employee>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 extension LeftJoinDepartmentEmployeeExt
@@ -390,7 +390,7 @@ extension LeftJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department>, Expr<Employee?>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 extension RightJoinDepartmentEmployeeExt
@@ -399,7 +399,7 @@ extension RightJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department?>, Expr<Employee>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 /// `Table<Department>` conflict targets for use with `.onConflict`.
@@ -887,7 +887,7 @@ extension ExpressionEmployeeExt on Expr<Employee> {
   /// is equal to [departmentId], if any.
   Expr<Department?> get department => $ForGeneratedCode
       .subqueryTable(_$Department._$table)
-      .where((r) => r.departmentId.equals(departmentId))
+      .where((r) => departmentId.equals(r.departmentId))
       .first;
 }
 
@@ -938,7 +938,7 @@ extension InnerJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee>, Expr<Department>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 extension LeftJoinEmployeeDepartmentExt
@@ -947,7 +947,7 @@ extension LeftJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee>, Expr<Department?>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 extension RightJoinEmployeeDepartmentExt
@@ -956,7 +956,7 @@ extension RightJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee?>, Expr<Department>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 /// `Table<Employee>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/expr/datetime_test.dart
+++ b/typed_sql/test/typed_sql/expr/datetime_test.dart
@@ -53,12 +53,12 @@ final _cases = [
   ),
   (
     name: 'epoch.equals(null)',
-    expr: toExpr(epoch).equals(toExpr(null)),
+    expr: (toExpr(epoch) as Expr<DateTime?>).equals(toExpr(null)),
     expected: false,
   ),
   (
     name: 'today.equals(null)',
-    expr: toExpr(today).equals(toExpr(null)),
+    expr: (toExpr(today) as Expr<DateTime?>).equals(toExpr(null)),
     expected: false,
   ),
 
@@ -95,12 +95,12 @@ final _cases = [
   ),
   (
     name: 'epoch.equalsValue(null)',
-    expr: toExpr(epoch).equalsValue(null),
+    expr: (toExpr(epoch) as Expr<DateTime?>).equalsValue(null),
     expected: false,
   ),
   (
     name: 'today.equalsValue(null)',
-    expr: toExpr(today).equalsValue(null),
+    expr: (toExpr(today) as Expr<DateTime?>).equalsValue(null),
     expected: false,
   ),
 
@@ -139,12 +139,12 @@ final _cases = [
   ),
   (
     name: 'epoch.notEquals(null)',
-    expr: toExpr(epoch).notEquals(toExpr(null)),
+    expr: (toExpr(epoch) as Expr<DateTime?>).notEquals(toExpr(null)),
     expected: true,
   ),
   (
     name: 'today.notEquals(null)',
-    expr: toExpr(today).notEquals(toExpr(null)),
+    expr: (toExpr(today) as Expr<DateTime?>).notEquals(toExpr(null)),
     expected: true,
   ),
 
@@ -181,12 +181,12 @@ final _cases = [
   ),
   (
     name: 'epoch.notEqualsValue(null)',
-    expr: toExpr(epoch).notEqualsValue(null),
+    expr: (toExpr(epoch) as Expr<DateTime?>).notEqualsValue(null),
     expected: true,
   ),
   (
     name: 'today.notEqualsValue(null)',
-    expr: toExpr(today).notEqualsValue(null),
+    expr: (toExpr(today) as Expr<DateTime?>).notEqualsValue(null),
     expected: true,
   ),
 

--- a/typed_sql/test/typed_sql/expr/double_expr_test.dart
+++ b/typed_sql/test/typed_sql/expr/double_expr_test.dart
@@ -50,12 +50,12 @@ final _cases = [
   ),
   (
     name: '0.0.equals(null)',
-    expr: toExpr(0.0).equals(toExpr(null)),
+    expr: (toExpr(0.0) as Expr<double?>).equals(toExpr(null)),
     expected: false,
   ),
   (
     name: '3.14.equals(null)',
-    expr: toExpr(3.14).equals(toExpr(null)),
+    expr: (toExpr(3.14) as Expr<double?>).equals(toExpr(null)),
     expected: false,
   ),
 
@@ -92,12 +92,12 @@ final _cases = [
   ),
   (
     name: '0.0.equalsValue(null)',
-    expr: toExpr(0.0).equalsValue(null),
+    expr: (toExpr(0.0) as Expr<double?>).equalsValue(null),
     expected: false,
   ),
   (
     name: '3.14.equalsValue(null)',
-    expr: toExpr(3.14).equalsValue(null),
+    expr: (toExpr(3.14) as Expr<double?>).equalsValue(null),
     expected: false,
   ),
 
@@ -134,12 +134,12 @@ final _cases = [
   ),
   (
     name: '0.0.notEquals(null)',
-    expr: toExpr(0.0).notEquals(toExpr(null)),
+    expr: (toExpr(0.0) as Expr<double?>).notEquals(toExpr(null)),
     expected: true,
   ),
   (
     name: '3.14.notEquals(null)',
-    expr: toExpr(3.14).notEquals(toExpr(null)),
+    expr: (toExpr(3.14) as Expr<double?>).notEquals(toExpr(null)),
     expected: true,
   ),
 
@@ -176,12 +176,12 @@ final _cases = [
   ),
   (
     name: '0.0.notEqualsValue(null)',
-    expr: toExpr(0.0).notEqualsValue(null),
+    expr: (toExpr(0.0) as Expr<double?>).notEqualsValue(null),
     expected: true,
   ),
   (
     name: '3.14.notEqualsValue(null)',
-    expr: toExpr(3.14).notEqualsValue(null),
+    expr: (toExpr(3.14) as Expr<double?>).notEqualsValue(null),
     expected: true,
   ),
 

--- a/typed_sql/test/typed_sql/expr/int_expr_test.dart
+++ b/typed_sql/test/typed_sql/expr/int_expr_test.dart
@@ -50,12 +50,12 @@ final _cases = [
   ),
   (
     name: '0.equals(null)',
-    expr: toExpr(0).equals(toExpr(null)),
+    expr: (toExpr(0) as Expr<int?>).equals(toExpr(null)),
     expected: false,
   ),
   (
     name: '42.equals(null)',
-    expr: toExpr(42).equals(toExpr(null)),
+    expr: (toExpr(42) as Expr<int?>).equals(toExpr(null)),
     expected: false,
   ),
 
@@ -92,12 +92,12 @@ final _cases = [
   ),
   (
     name: '0.equalsValue(null)',
-    expr: toExpr(0).equalsValue(null),
+    expr: (toExpr(0) as Expr<int?>).equalsValue(null),
     expected: false,
   ),
   (
     name: '42.equalsValue(null)',
-    expr: toExpr(42).equalsValue(null),
+    expr: (toExpr(42) as Expr<int?>).equalsValue(null),
     expected: false,
   ),
 
@@ -134,12 +134,12 @@ final _cases = [
   ),
   (
     name: '0.notEquals(null)',
-    expr: toExpr(0).notEquals(toExpr(null)),
+    expr: (toExpr(0) as Expr<int?>).notEquals(toExpr(null)),
     expected: true,
   ),
   (
     name: '42.notEquals(null)',
-    expr: toExpr(42).notEquals(toExpr(null)),
+    expr: (toExpr(42) as Expr<int?>).notEquals(toExpr(null)),
     expected: true,
   ),
 
@@ -176,12 +176,12 @@ final _cases = [
   ),
   (
     name: '0.notEqualsValue(null)',
-    expr: toExpr(0).notEqualsValue(null),
+    expr: (toExpr(0) as Expr<int?>).notEqualsValue(null),
     expected: true,
   ),
   (
     name: '42.notEqualsValue(null)',
-    expr: toExpr(42).notEqualsValue(null),
+    expr: (toExpr(42) as Expr<int?>).notEqualsValue(null),
     expected: true,
   ),
 

--- a/typed_sql/test/typed_sql/expr/string_expr_test.dart
+++ b/typed_sql/test/typed_sql/expr/string_expr_test.dart
@@ -105,12 +105,12 @@ final _cases = [
   ),
   (
     name: '"".equals(null)',
-    expr: toExpr('').equals(toExpr(null)),
+    expr: (toExpr('') as Expr<String?>).equals(toExpr(null)),
     expected: false,
   ),
   (
     name: '"hello".equals(null)',
-    expr: toExpr('hello').equals(toExpr(null)),
+    expr: (toExpr('hello') as Expr<String?>).equals(toExpr(null)),
     expected: false,
   ),
 
@@ -142,12 +142,12 @@ final _cases = [
   ),
   (
     name: '"".equalsValue(null)',
-    expr: toExpr('').equalsValue(null),
+    expr: (toExpr('') as Expr<String?>).equalsValue(null),
     expected: false,
   ),
   (
     name: '"hello".equalsValue(null)',
-    expr: toExpr('hello').equalsValue(null),
+    expr: (toExpr('hello') as Expr<String?>).equalsValue(null),
     expected: false,
   ),
 
@@ -179,12 +179,12 @@ final _cases = [
   ),
   (
     name: '"".notEquals(null)',
-    expr: toExpr('').notEquals(toExpr(null)),
+    expr: (toExpr('') as Expr<String?>).notEquals(toExpr(null)),
     expected: true,
   ),
   (
     name: '"hello".notEquals(null)',
-    expr: toExpr('hello').notEquals(toExpr(null)),
+    expr: (toExpr('hello') as Expr<String?>).notEquals(toExpr(null)),
     expected: true,
   ),
 
@@ -216,12 +216,12 @@ final _cases = [
   ),
   (
     name: '"".notEqualsValue(null)',
-    expr: toExpr('').notEqualsValue(null),
+    expr: (toExpr('') as Expr<String?>).notEqualsValue(null),
     expected: true,
   ),
   (
     name: '"hello".notEqualsValue(null)',
-    expr: toExpr('hello').notEqualsValue(null),
+    expr: (toExpr('hello') as Expr<String?>).notEqualsValue(null),
     expected: true,
   ),
 

--- a/typed_sql/test/typed_sql/expr/uint8list_expr_test.dart
+++ b/typed_sql/test/typed_sql/expr/uint8list_expr_test.dart
@@ -71,9 +71,12 @@ final _cases =
       ),
       (
         name: '[1,2,3].equals(null)',
-        expr: toExpr(
-          Uint8List.fromList([1, 2, 3]),
-        ).equals(toExpr(null as Uint8List?)),
+        expr:
+            (toExpr(
+                      Uint8List.fromList([1, 2, 3]),
+                    )
+                    as Expr<Uint8List?>)
+                .equals(toExpr(null as Uint8List?)),
         expected: false,
       ),
 
@@ -122,7 +125,8 @@ final _cases =
       ),
       (
         name: '[1,2,3].equalsValue(null)',
-        expr: toExpr(Uint8List.fromList([1, 2, 3])).equalsValue(null),
+        expr: (toExpr(Uint8List.fromList([1, 2, 3])) as Expr<Uint8List?>)
+            .equalsValue(null),
         expected: false,
       ),
 
@@ -171,9 +175,12 @@ final _cases =
       ),
       (
         name: '[1,2,3].notEquals(null)',
-        expr: toExpr(
-          Uint8List.fromList([1, 2, 3]),
-        ).notEquals(toExpr(null as Uint8List?)),
+        expr:
+            (toExpr(
+                      Uint8List.fromList([1, 2, 3]),
+                    )
+                    as Expr<Uint8List?>)
+                .notEquals(toExpr(null as Uint8List?)),
         expected: true,
       ),
 
@@ -222,7 +229,8 @@ final _cases =
       ),
       (
         name: '[1,2,3].notEqualsValue(null)',
-        expr: toExpr(Uint8List.fromList([1, 2, 3])).notEqualsValue(null),
+        expr: (toExpr(Uint8List.fromList([1, 2, 3])) as Expr<Uint8List?>)
+            .notEqualsValue(null),
         expected: true,
       ),
 

--- a/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.dart
+++ b/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.dart
@@ -268,8 +268,8 @@ void main() {
         .join(db.books)
         .on(
           (author, book) =>
-              author.firstName.equals(book.authorFirstName) &
-              author.lastName.equals(book.authorLastName),
+              book.authorFirstName.equals(author.firstName) &
+              book.authorLastName.equals(author.lastName),
         )
         .groupBy((author, book) => (author,))
         .aggregate(

--- a/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
@@ -371,8 +371,8 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   /// This will match rows where [Author.firstName] = [Book.authorFirstName] and [Author.lastName] = [Book.authorLastName].
   Query<(Expr<Author>, Expr<Book>)> usingAuthor() => on(
     (a, b) =>
-        a.firstName.equals(b.authorFirstName) &
-        a.lastName.equals(b.authorLastName),
+        b.authorFirstName.equals(a.firstName) &
+        b.authorLastName.equals(a.lastName),
   );
 }
 
@@ -382,8 +382,8 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   /// This will match rows where [Author.firstName] = [Book.authorFirstName] and [Author.lastName] = [Book.authorLastName].
   Query<(Expr<Author>, Expr<Book?>)> usingAuthor() => on(
     (a, b) =>
-        a.firstName.equals(b.authorFirstName) &
-        a.lastName.equals(b.authorLastName),
+        b.authorFirstName.equals(a.firstName) &
+        b.authorLastName.equals(a.lastName),
   );
 }
 
@@ -393,8 +393,8 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   /// This will match rows where [Author.firstName] = [Book.authorFirstName] and [Author.lastName] = [Book.authorLastName].
   Query<(Expr<Author?>, Expr<Book>)> usingAuthor() => on(
     (a, b) =>
-        a.firstName.equals(b.authorFirstName) &
-        a.lastName.equals(b.authorLastName),
+        b.authorFirstName.equals(a.firstName) &
+        b.authorLastName.equals(a.lastName),
   );
 }
 
@@ -961,8 +961,8 @@ extension ExpressionBookExt on Expr<Book> {
       .subqueryTable(_$Author._$table)
       .where(
         (r) =>
-            r.firstName.equals(authorFirstName) &
-            r.lastName.equals(authorLastName),
+            authorFirstName.equals(r.firstName) &
+            authorLastName.equals(r.lastName),
       )
       .first;
 }
@@ -1024,8 +1024,8 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   /// This will match rows where [Book.authorFirstName] = [Author.firstName] and [Book.authorLastName] = [Author.lastName].
   Query<(Expr<Book>, Expr<Author>)> usingAuthor() => on(
     (a, b) =>
-        b.firstName.equals(a.authorFirstName) &
-        b.lastName.equals(a.authorLastName),
+        a.authorFirstName.equals(b.firstName) &
+        a.authorLastName.equals(b.lastName),
   );
 }
 
@@ -1035,8 +1035,8 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   /// This will match rows where [Book.authorFirstName] = [Author.firstName] and [Book.authorLastName] = [Author.lastName].
   Query<(Expr<Book>, Expr<Author?>)> usingAuthor() => on(
     (a, b) =>
-        b.firstName.equals(a.authorFirstName) &
-        b.lastName.equals(a.authorLastName),
+        a.authorFirstName.equals(b.firstName) &
+        a.authorLastName.equals(b.lastName),
   );
 }
 
@@ -1046,8 +1046,8 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   /// This will match rows where [Book.authorFirstName] = [Author.firstName] and [Book.authorLastName] = [Author.lastName].
   Query<(Expr<Book?>, Expr<Author>)> usingAuthor() => on(
     (a, b) =>
-        b.firstName.equals(a.authorFirstName) &
-        b.lastName.equals(a.authorLastName),
+        a.authorFirstName.equals(b.firstName) &
+        a.authorLastName.equals(b.lastName),
   );
 }
 

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
@@ -380,7 +380,7 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -388,7 +388,7 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book?>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -396,7 +396,7 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author?>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -909,7 +909,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [authorId], if any.
   Expr<Author?> get author => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(authorId))
+      .where((r) => authorId.equals(r.authorId))
       .first;
 }
 
@@ -962,7 +962,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -970,7 +970,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -978,7 +978,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
@@ -380,7 +380,7 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -388,7 +388,7 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book?>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -396,7 +396,7 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author?>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -909,7 +909,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [authorId], if any.
   Expr<Author?> get author => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(authorId))
+      .where((r) => authorId.equals(r.authorId))
       .first;
 }
 
@@ -962,7 +962,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -970,7 +970,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -978,7 +978,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
@@ -380,7 +380,7 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -388,7 +388,7 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book?>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -396,7 +396,7 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author?>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -909,7 +909,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [authorId], if any.
   Expr<Author?> get author => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(authorId))
+      .where((r) => authorId.equals(r.authorId))
       .first;
 }
 
@@ -962,7 +962,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -970,7 +970,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -978,7 +978,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
@@ -380,7 +380,7 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -388,7 +388,7 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author>, Expr<Book?>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -396,7 +396,7 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.authorId].
   Query<(Expr<Author?>, Expr<Book>)> usingAuthor() =>
-      on((a, b) => a.authorId.equals(b.authorId));
+      on((a, b) => b.authorId.equals(a.authorId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -909,7 +909,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [authorId], if any.
   Expr<Author?> get author => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(authorId))
+      .where((r) => authorId.equals(r.authorId))
       .first;
 }
 
@@ -962,7 +962,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -970,7 +970,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -978,7 +978,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.authorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingAuthor() =>
-      on((a, b) => b.authorId.equals(a.authorId));
+      on((a, b) => a.authorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/join/join_model/join_model_test.dart
+++ b/typed_sql/test/typed_sql/join/join_model/join_model_test.dart
@@ -563,7 +563,7 @@ void main() {
         .leftJoin(db.employees)
         .on(
           (department, employee) =>
-              department.departmentId.equals(employee.departmentId),
+              employee.departmentId.equals(department.departmentId),
         )
         .groupBy((department, employee) => (department.name,))
         .aggregate(

--- a/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
@@ -340,7 +340,7 @@ extension ExpressionEmployeeExt on Expr<Employee> {
   /// is equal to [departmentId], if any.
   Expr<Department?> get department => $ForGeneratedCode
       .subqueryTable(_$Department._$table)
-      .where((r) => r.departmentId.equals(departmentId))
+      .where((r) => departmentId.equals(r.departmentId))
       .first;
 }
 
@@ -391,7 +391,7 @@ extension InnerJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee>, Expr<Department>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 extension LeftJoinEmployeeDepartmentExt
@@ -400,7 +400,7 @@ extension LeftJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee>, Expr<Department?>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 extension RightJoinEmployeeDepartmentExt
@@ -409,7 +409,7 @@ extension RightJoinEmployeeDepartmentExt
   ///
   /// This will match rows where [Employee.departmentId] = [Department.departmentId].
   Query<(Expr<Employee?>, Expr<Department>)> usingDepartment() =>
-      on((a, b) => b.departmentId.equals(a.departmentId));
+      on((a, b) => a.departmentId.equals(b.departmentId));
 }
 
 /// `Table<Employee>` conflict targets for use with `.onConflict`.
@@ -938,7 +938,7 @@ extension InnerJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department>, Expr<Employee>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 extension LeftJoinDepartmentEmployeeExt
@@ -947,7 +947,7 @@ extension LeftJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department>, Expr<Employee?>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 extension RightJoinDepartmentEmployeeExt
@@ -956,7 +956,7 @@ extension RightJoinDepartmentEmployeeExt
   ///
   /// This will match rows where [Department.departmentId] = [Employee.departmentId].
   Query<(Expr<Department?>, Expr<Employee>)> usingDepartment() =>
-      on((a, b) => a.departmentId.equals(b.departmentId));
+      on((a, b) => b.departmentId.equals(a.departmentId));
 }
 
 /// `Table<Department>` conflict targets for use with `.onConflict`.

--- a/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
@@ -357,7 +357,7 @@ extension ExpressionAuthorExt on Expr<Author> {
   /// is equal to [favoriteBookId], if any.
   Expr<Book?> get favoriteBook => $ForGeneratedCode
       .subqueryTable(_$Book._$table)
-      .where((r) => r.bookId.equals(favoriteBookId))
+      .where((r) => favoriteBookId.equals(r.bookId))
       .first;
 }
 
@@ -439,13 +439,13 @@ extension InnerJoinAuthorBookExt on InnerJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author>, Expr<Book>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author>, Expr<Book>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -459,13 +459,13 @@ extension LeftJoinAuthorBookExt on LeftJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author>, Expr<Book?>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author>, Expr<Book?>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
@@ -479,13 +479,13 @@ extension RightJoinAuthorBookExt on RightJoin<(Expr<Author>,), (Expr<Book>,)> {
   ///
   /// This will match rows where [Author.authorId] = [Book.editorId].
   Query<(Expr<Author?>, Expr<Book>)> usingEditor() =>
-      on((a, b) => a.authorId.equals(b.editorId));
+      on((a, b) => b.editorId.equals(a.authorId));
 
   /// Join using the `favoriteBook` _foreign key_.
   ///
   /// This will match rows where [Author.favoriteBookId] = [Book.bookId].
   Query<(Expr<Author?>, Expr<Book>)> usingFavoriteBook() =>
-      on((a, b) => b.bookId.equals(a.favoriteBookId));
+      on((a, b) => a.favoriteBookId.equals(b.bookId));
 }
 
 /// `Table<Author>` conflict targets for use with `.onConflict`.
@@ -1066,7 +1066,7 @@ extension ExpressionBookExt on Expr<Book> {
   /// is equal to [editorId], if any.
   Expr<Author?> get editor => $ForGeneratedCode
       .subqueryTable(_$Author._$table)
-      .where((r) => r.authorId.equals(editorId))
+      .where((r) => editorId.equals(r.authorId))
       .first;
 }
 
@@ -1150,7 +1150,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book>, Expr<Author>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1162,7 +1162,7 @@ extension InnerJoinBookAuthorExt on InnerJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -1170,7 +1170,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book>, Expr<Author?>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1182,7 +1182,7 @@ extension LeftJoinBookAuthorExt on LeftJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book>, Expr<Author?>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
@@ -1190,7 +1190,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.bookId] = [Author.favoriteBookId].
   Query<(Expr<Book?>, Expr<Author>)> usingFavoriteBook() =>
-      on((a, b) => a.bookId.equals(b.favoriteBookId));
+      on((a, b) => b.favoriteBookId.equals(a.bookId));
 
   /// Join using the `author` _foreign key_.
   ///
@@ -1202,7 +1202,7 @@ extension RightJoinBookAuthorExt on RightJoin<(Expr<Book>,), (Expr<Author>,)> {
   ///
   /// This will match rows where [Book.editorId] = [Author.authorId].
   Query<(Expr<Book?>, Expr<Author>)> usingEditor() =>
-      on((a, b) => b.authorId.equals(a.editorId));
+      on((a, b) => a.editorId.equals(b.authorId));
 }
 
 /// `Table<Book>` conflict targets for use with `.onConflict`.


### PR DESCRIPTION
- Switches the `ExpressionNullable<Type>` and `Expression<Type>` extensions' `.equals` and `.equalsValue` logic: non-nullable can get only the non-nullable value parameters.
- Updates the code generator's equals generator: we select the more lenient expression (if the FK is nullable, we use that, otherwise the referenced PK expression) as the lead object for the `.equals` call, that way if one of them is nullable but the other is not, we still generate type-safe and correct code.
- Updated tests.
- Verified pub-dev's use case, confirmed that it removes the COALESCE expressions without further modification.
