### PR TITLE
Support paginated table fetching using primary keys as cursor.

### DIFF
--- a/typed_sql/CHANGELOG.md
+++ b/typed_sql/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.14
+ * Support paginated table fetching using primary keys as cursor.
+
 ## 0.1.13
  * Support `CREATE INDEX` DDLs through `@Index` annotations.
 

--- a/typed_sql/example/lib/src/model.g.dart
+++ b/typed_sql/example/lib/src/model.g.dart
@@ -179,6 +179,66 @@ extension TableUserExt on Table<User> {
       $ForGeneratedCode.deleteSingle(byKey(userId), _$User._$table);
 }
 
+/// Pagination cursor referencing a row in [User].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class UserCursor {
+  const UserCursor({required this.userId});
+
+  final int userId;
+
+  @override
+  String toString() => 'UserCursor(userId: "$userId")';
+}
+
+/// Sort direction for each _primary key_ field of [User], used by
+/// `.fetchPage(...)`.
+final class UserDirection {
+  const UserDirection({this.userId = Order.ascending});
+
+  final Order userId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [User].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class UserPageRequest implements PageRequest<User, UserCursor> {
+  const UserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const UserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final UserCursor? cursor;
+
+  final UserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<User> user) => [
+    (user.userId, direction.userId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<User> user) => direction.userId == Order.ascending
+      ? user.userId > toExpr(cursor!.userId)
+      : user.userId < toExpr(cursor!.userId);
+
+  @override
+  UserCursor cursorOf(User user) => UserCursor(userId: user.userId);
+
+  @override
+  UserPageRequest withCursor(UserCursor cursor) =>
+      UserPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `users` table.
 extension QueryUserExt on Query<(Expr<User>,)> {
   /// Lookup a single row in `users` table using the _primary key_.
@@ -187,6 +247,30 @@ extension QueryUserExt on Query<(Expr<User>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<User>,)> byKey(int userId) =>
       where((user) => user.userId.equalsValue(userId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<User, UserCursor>? request =
+  ///     UserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [UserCursor].
+  Future<Page<User, UserCursor>> fetchPage(
+    PageRequest<User, UserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<User, UserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `users` table matching this [Query].
   ///
@@ -757,6 +841,71 @@ extension TablePackageExt on Table<Package> {
       $ForGeneratedCode.deleteSingle(byKey(packageName), _$Package._$table);
 }
 
+/// Pagination cursor referencing a row in [Package].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class PackageCursor {
+  const PackageCursor({required this.packageName});
+
+  final String packageName;
+
+  @override
+  String toString() => 'PackageCursor(packageName: "$packageName")';
+}
+
+/// Sort direction for each _primary key_ field of [Package], used by
+/// `.fetchPage(...)`.
+final class PackageDirection {
+  const PackageDirection({this.packageName = Order.ascending});
+
+  final Order packageName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Package].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class PackagePageRequest implements PageRequest<Package, PackageCursor> {
+  const PackagePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const PackageDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final PackageCursor? cursor;
+
+  final PackageDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Package> package) => [
+    (package.packageName, direction.packageName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Package> package) =>
+      direction.packageName == Order.ascending
+      ? package.packageName > toExpr(cursor!.packageName)
+      : package.packageName < toExpr(cursor!.packageName);
+
+  @override
+  PackageCursor cursorOf(Package package) =>
+      PackageCursor(packageName: package.packageName);
+
+  @override
+  PackagePageRequest withCursor(PackageCursor cursor) => PackagePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `packages` table.
 extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// Lookup a single row in `packages` table using the _primary key_.
@@ -765,6 +914,30 @@ extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Package>,)> byKey(String packageName) =>
       where((package) => package.packageName.equalsValue(packageName)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Package, PackageCursor>? request =
+  ///     PackagePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [PackageCursor].
+  Future<Page<Package, PackageCursor>> fetchPage(
+    PageRequest<Package, PackageCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Package, PackageCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `packages` table matching this [Query].
   ///
@@ -1317,6 +1490,83 @@ extension TableLikeExt on Table<Like> {
       .deleteSingle(byKey(userId, packageName), _$Like._$table);
 }
 
+/// Pagination cursor referencing a row in [Like].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class LikeCursor {
+  const LikeCursor({required this.userId, required this.packageName});
+
+  final int userId;
+
+  final String packageName;
+
+  @override
+  String toString() =>
+      'LikeCursor(userId: "$userId", packageName: "$packageName")';
+}
+
+/// Sort direction for each _primary key_ field of [Like], used by
+/// `.fetchPage(...)`.
+final class LikeDirection {
+  const LikeDirection({
+    this.userId = Order.ascending,
+    this.packageName = Order.ascending,
+  });
+
+  final Order userId;
+
+  final Order packageName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Like].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class LikePageRequest implements PageRequest<Like, LikeCursor> {
+  const LikePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const LikeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final LikeCursor? cursor;
+
+  final LikeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Like> like) => [
+    (like.userId, direction.userId),
+    (like.packageName, direction.packageName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Like> like) =>
+      (direction.userId == Order.ascending
+              ? like.userId > toExpr(cursor!.userId)
+              : like.userId < toExpr(cursor!.userId))
+          .or(
+            like.userId.equalsValue(cursor!.userId) &
+                (direction.packageName == Order.ascending
+                    ? like.packageName > toExpr(cursor!.packageName)
+                    : like.packageName < toExpr(cursor!.packageName)),
+          );
+
+  @override
+  LikeCursor cursorOf(Like like) =>
+      LikeCursor(userId: like.userId, packageName: like.packageName);
+
+  @override
+  LikePageRequest withCursor(LikeCursor cursor) =>
+      LikePageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `likes` table.
 extension QueryLikeExt on Query<(Expr<Like>,)> {
   /// Lookup a single row in `likes` table using the _primary key_.
@@ -1328,6 +1578,30 @@ extension QueryLikeExt on Query<(Expr<Like>,)> {
         like.userId.equalsValue(userId) &
         like.packageName.equalsValue(packageName),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Like, LikeCursor>? request =
+  ///     LikePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [LikeCursor].
+  Future<Page<Like, LikeCursor>> fetchPage(
+    PageRequest<Like, LikeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Like, LikeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `likes` table matching this [Query].
   ///

--- a/typed_sql/lib/src/codegen/build_code.dart
+++ b/typed_sql/lib/src/codegen/build_code.dart
@@ -356,6 +356,39 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
     ''';
   }
 
+  // Build the "row is after cursor" where predicate, as a lexicographic
+  // OR-chain over the primary key fields:
+  //   (k1 < c1) | (k1 == c1 & k2 < c2) | ... | (k1 == c1 & ... & kn < cn)
+  //
+  // Each field has its own sort direction.
+  String wherePredicateExpr() {
+    String comparison(ParsedField f) =>
+        'direction.${f.name} == Order.ascending'
+        ' ? $rowInstanceName.${f.name} > toExpr(cursor!.${f.name})'
+        ' : $rowInstanceName.${f.name} < toExpr(cursor!.${f.name})';
+
+    final pk = rowClass.primaryKey;
+    if (pk.length == 1) {
+      return comparison(pk.single);
+    }
+
+    // condition snippets with `==` on PK fields
+    final eqParts = List.generate(
+      pk.length - 1,
+      (i) =>
+          '$rowInstanceName.${pk[i].name}.equalsValue(cursor!.${pk[i].name})',
+    );
+
+    // conditions parts with `k1 == c1 & kn < cn`
+    final items = List.generate(
+      pk.length,
+      (i) => [...eqParts.take(i), '(${comparison(pk[i])})'].join(' & '),
+    );
+
+    // creates the complete a.or(b).or(c) expression
+    return items.mapIndexed((i, s) => i == 0 ? s : '($s)').join('.or');
+  }
+
   // Create implementation class for Row
   yield Class(
     (b) => b
@@ -715,6 +748,224 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
       ),
   );
 
+  // Cursor class for `.fetchPage()`, generated only when every primary key
+  // field supports pagination comparisons.
+  final isAllPkOrderable = rowClass.primaryKey.every((f) => f.isOrderable);
+  if (isAllPkOrderable) {
+    yield Class(
+      (b) => b
+        ..name = '${rowClassName}Cursor'
+        ..modifier = ClassModifier.final$
+        ..documentation(docs.fetchPageCursor(rowClassName))
+        ..constructors.add(
+          Constructor(
+            (b) => b
+              ..constant = true
+              ..optionalParameters.addAll(
+                rowClass.primaryKey.map(
+                  (pk) => Parameter(
+                    (b) => b
+                      ..name = pk.name
+                      ..named = true
+                      ..required = true
+                      ..toThis = true,
+                  ),
+                ),
+              ),
+          ),
+        )
+        ..fields.addAll(
+          rowClass.primaryKey.map(
+            (pk) => Field(
+              (b) => b
+                ..name = pk.name
+                ..modifier = FieldModifier.final$
+                ..type = refer(pk.typeName),
+            ),
+          ),
+        )
+        ..methods.add(
+          Method(
+            (b) => b
+              ..name = 'toString'
+              ..annotations.add(refer('override'))
+              ..returns = refer('String')
+              ..lambda = true
+              ..body = Code(
+                '\'${rowClassName}Cursor(${rowClass.primaryKey.map((f) => '${f.name}: "\$${f.name}"').join(', ')})\'',
+              ),
+          ),
+        ),
+    );
+
+    // Sort direction for `.fetchPage()`, one field per primary key column,
+    // each individually defaulting to ascending.
+    yield Class(
+      (b) => b
+        ..name = '${rowClassName}Direction'
+        ..modifier = ClassModifier.final$
+        ..documentation(docs.fetchPageDirection(rowClassName))
+        ..constructors.add(
+          Constructor(
+            (b) => b
+              ..constant = true
+              ..optionalParameters.addAll(
+                rowClass.primaryKey.map(
+                  (pk) => Parameter(
+                    (b) => b
+                      ..name = pk.name
+                      ..named = true
+                      ..toThis = true
+                      ..defaultTo = Code('Order.ascending'),
+                  ),
+                ),
+              ),
+          ),
+        )
+        ..fields.addAll(
+          rowClass.primaryKey.map(
+            (pk) => Field(
+              (b) => b
+                ..name = pk.name
+                ..modifier = FieldModifier.final$
+                ..type = refer('Order'),
+            ),
+          ),
+        ),
+    );
+
+    // Table-specific pagination request fields, based on the primary keys.
+    final orderByExprs = rowClass.primaryKey
+        .map((f) => '($rowInstanceName.${f.name}, direction.${f.name})')
+        .join(', ');
+    final cursorFields = rowClass.primaryKey
+        .map((f) => '${f.name}: $rowInstanceName.${f.name}')
+        .join(', ');
+    yield Class(
+      (b) => b
+        ..name = '${rowClassName}PageRequest'
+        ..modifier = ClassModifier.final$
+        ..implements.add(
+          refer('PageRequest<$rowClassName, ${rowClassName}Cursor>'),
+        )
+        ..documentation(docs.fetchPageRequest(rowClassName))
+        ..constructors.add(
+          Constructor(
+            (b) => b
+              ..constant = true
+              ..optionalParameters.addAll([
+                Parameter(
+                  (b) => b
+                    ..name = 'pageSize'
+                    ..named = true
+                    ..required = true
+                    ..toThis = true,
+                ),
+                Parameter(
+                  (b) => b
+                    ..name = 'cursor'
+                    ..named = true
+                    ..toThis = true,
+                ),
+                Parameter(
+                  (b) => b
+                    ..name = 'direction'
+                    ..named = true
+                    ..toThis = true
+                    ..defaultTo = Code('const ${rowClassName}Direction()'),
+                ),
+              ]),
+          ),
+        )
+        ..fields.addAll([
+          Field(
+            (b) => b
+              ..name = 'pageSize'
+              ..annotations.add(refer('override'))
+              ..modifier = FieldModifier.final$
+              ..type = refer('int'),
+          ),
+          Field(
+            (b) => b
+              ..name = 'cursor'
+              ..annotations.add(refer('override'))
+              ..modifier = FieldModifier.final$
+              ..type = refer('${rowClassName}Cursor?'),
+          ),
+          Field(
+            (b) => b
+              ..name = 'direction'
+              ..modifier = FieldModifier.final$
+              ..type = refer('${rowClassName}Direction'),
+          ),
+        ])
+        ..methods.addAll([
+          Method(
+            (b) => b
+              ..name = 'orderBy'
+              ..annotations.add(refer('override'))
+              ..returns = refer('List<(Expr<Comparable?>, Order)>')
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = rowInstanceName
+                    ..type = refer('Expr<$rowClassName>'),
+                ),
+              )
+              ..lambda = true
+              ..body = Code('[$orderByExprs]'),
+          ),
+          Method(
+            (b) => b
+              ..name = 'where'
+              ..annotations.add(refer('override'))
+              ..returns = refer('Expr<bool?>')
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = rowInstanceName
+                    ..type = refer('Expr<$rowClassName>'),
+                ),
+              )
+              ..lambda = true
+              ..body = Code(wherePredicateExpr()),
+          ),
+          Method(
+            (b) => b
+              ..name = 'cursorOf'
+              ..annotations.add(refer('override'))
+              ..returns = refer('${rowClassName}Cursor')
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = rowInstanceName
+                    ..type = refer(rowClassName),
+                ),
+              )
+              ..lambda = true
+              ..body = Code('${rowClassName}Cursor($cursorFields)'),
+          ),
+          Method(
+            (b) => b
+              ..name = 'withCursor'
+              ..annotations.add(refer('override'))
+              ..returns = refer('${rowClassName}PageRequest')
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = 'cursor'
+                    ..type = refer('${rowClassName}Cursor'),
+                ),
+              )
+              ..lambda = true
+              ..body = Code(
+                '${rowClassName}PageRequest(pageSize: pageSize, cursor: cursor, direction: direction)',
+              ),
+          ),
+        ]),
+    );
+  }
+
   // Extension for Query<(Expr<Row>,)>
   yield Extension(
     (b) => b
@@ -756,6 +1007,33 @@ Iterable<Spec> buildTable(ParsedTable table, ParsedSchema schema) sync* {
             ..body = Code('where(($rowInstanceName) => $whereExpr).first');
         }),
       )
+      ..methods.addAll([
+        if (isAllPkOrderable)
+          Method(
+            (b) => b
+              ..name = 'fetchPage'
+              ..documentation(docs.fetchPage(rowClassName))
+              ..returns = refer(
+                'Future<Page<$rowClassName, ${rowClassName}Cursor>>',
+              )
+              ..requiredParameters.add(
+                Parameter(
+                  (b) => b
+                    ..name = 'request'
+                    ..type = refer(
+                      'PageRequest<$rowClassName, ${rowClassName}Cursor>',
+                    ),
+                ),
+              )
+              ..lambda = true
+              ..body = Code('''
+                \$ForGeneratedCode.fetchPage<$rowClassName, ${rowClassName}Cursor>(
+                  query: this,
+                  request: request,
+                )
+              '''),
+          ),
+      ])
       ..methods.add(
         Method(
           (b) => b
@@ -1716,6 +1994,11 @@ extension on ParsedField {
 
   bool get isCustomType => backingType != typeName;
 
+  /// Whether this field has `<`, `<=`, `>` and `>=` comparison operators,
+  /// and is usable in a pagination.
+  bool get isOrderable =>
+      !isCustomType && _orderableBackingTypes.contains(backingType);
+
   String get sqlName {
     final nameOverride = overrides.map((o) => o.name).nonNulls.lastOrNull;
     if (nameOverride != null) {
@@ -1794,6 +2077,14 @@ extension on List<ParsedField> {
   List<ParsedField> get whereDefaultAndNullable =>
       where((f) => f.hasDefault && f.isNullable).toList();
 }
+
+const _orderableBackingTypes = {
+  'String',
+  'int',
+  'double',
+  'DateTime',
+  'Uint8List',
+};
 
 String backingExprType(String backingType) {
   return switch (backingType) {

--- a/typed_sql/lib/src/codegen/code_builder_ext.dart
+++ b/typed_sql/lib/src/codegen/code_builder_ext.dart
@@ -39,6 +39,12 @@ extension ExtensionBuilderExt on ExtensionBuilder {
   }
 }
 
+extension ClassBuilderExt on ClassBuilder {
+  void documentation(String content) {
+    docs.addAll(_documentationCommentLines(content));
+  }
+}
+
 Iterable<String> _documentationCommentLines(String content) sync* {
   final lines = _trimLines(content).split('\n');
 

--- a/typed_sql/lib/src/codegen/docs.dart
+++ b/typed_sql/lib/src/codegen/docs.dart
@@ -509,3 +509,52 @@ String onConflictUpdate(String rowInstanceName) =>
 
     [1]: https://www.sqlite.org/lang_upsert.html
 ''';
+
+/// Documentation for `.fetchPage` on `Query<(Expr<Row>,)>`.
+String fetchPage(String rowClassName) =>
+    '''
+    Fetch a page of at most `request.pageSize` rows.
+
+    For continuing an existing pagination, pass `page.nextPageRequest`
+    from the previous page as [request]:
+    ```dart
+    PageRequest<$rowClassName, ${rowClassName}Cursor>? request =
+        ${rowClassName}PageRequest(pageSize: 100);
+    while (request != null) {
+      final page = await db.myTable.fetchPage(request);
+      // ... process page.items ...
+      request = page.nextPageRequest;
+    }
+    ```
+
+    If you only need a resume point to persist (e.g. in a URL or a stored
+    checkpoint) rather than the whole request, use `page.nextCursor`
+    instead -- see [${rowClassName}Cursor].
+''';
+
+/// Documentation for the generated `${rowClassName}Cursor` class.
+String fetchPageCursor(String rowClassName) =>
+    '''
+    Pagination cursor referencing a row in [$rowClassName].
+
+    This identifies the row after which the next page of results begins,
+    using the values of the _primary key_ fields from that row.
+''';
+
+/// Documentation for the generated `${rowClassName}Direction` class.
+String fetchPageDirection(String rowClassName) =>
+    '''
+    Sort direction for each _primary key_ field of [$rowClassName], used by
+    `.fetchPage(...)`.
+''';
+
+/// Documentation for the generated `${rowClassName}PageRequest` class.
+String fetchPageRequest(String rowClassName) =>
+    '''
+    Parameters for a `.fetchPage(...)` call against [$rowClassName].
+
+    > [!WARNING]
+    > Always use the same [direction] for every page in a single pagination.
+    > Using a cursor obtained with one direction while fetching
+    > with a different direction will paginate the wrong way.
+''';

--- a/typed_sql/lib/src/typed_sql.dart
+++ b/typed_sql/lib/src/typed_sql.dart
@@ -33,6 +33,7 @@ part 'typed_sql.expr.dart';
 part 'typed_sql.expr_ext.dart';
 part 'typed_sql.g.dart';
 part 'typed_sql.mutation.dart';
+part 'typed_sql.pagination.dart';
 part 'typed_sql.query.dart';
 part 'typed_sql.query_ext.dart';
 part 'typed_sql.statements.dart';
@@ -346,6 +347,35 @@ final class $ForGeneratedCode {
     QuerySingle<(Expr<T>,)> query,
     TableDefinition<T> table,
   ) => DeleteSingle._(Delete._(query.asQuery, table));
+
+  static Future<Page<T, C>> fetchPage<T extends Row, C extends Object>({
+    required Query<(Expr<T>,)> query,
+    required PageRequest<T, C> request,
+  }) async {
+    final pageSize = request.pageSize;
+    if (pageSize < 1) {
+      throw ArgumentError.value(
+        pageSize,
+        'pageSize',
+        'must be a positive integer',
+      );
+    }
+    final filtered = request.cursor == null
+        ? query
+        : query.where(request.where);
+    // Fetch one extra row to determine `hasMore` without a second COUNT(*)
+    // query.
+    final rows = await filtered
+        .orderBy(request.orderBy)
+        .limit(pageSize + 1)
+        .fetch();
+    if (rows.length <= pageSize) {
+      return Page._(rows, null);
+    }
+    final items = rows.sublist(0, pageSize);
+    final cursor = request.cursorOf(items.last);
+    return Page._(items, request.withCursor(cursor));
+  }
 
   static UpdateSet<T> buildUpdate<T extends Row>(List<Expr?> values) =>
       UpdateSet._(values);

--- a/typed_sql/lib/src/typed_sql.pagination.dart
+++ b/typed_sql/lib/src/typed_sql.pagination.dart
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of 'typed_sql.dart';
+
+/// A [PageRequest] fully describes how to fetch one page:
+/// - how to order rows ([orderBy]),
+/// - how to filter to "rows after the cursor" ([where]),
+/// - how to build a cursor from a fetched row ([cursorOf]), and
+/// - how to build the request for the next page ([withCursor]).
+///
+/// Note: page fetching itself does not know about a concrete cursor
+/// or sort-direction, keeping it open for more generic paging queries.
+///
+/// {@category writing_queries}
+abstract interface class PageRequest<T extends Row, C extends Object> {
+  /// Maximum number of rows to fetch in a single [Page].
+  int get pageSize;
+
+  /// Cursor to fetch rows after, or `null` to fetch the first page.
+  C? get cursor;
+
+  /// Build the `ORDER BY` expressions for this request.
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<T> row);
+
+  /// Build the `WHERE` expression selecting rows after [cursor].
+  ///
+  /// Only ever called when [cursor] is not `null`.
+  Expr<bool?> where(Expr<T> row);
+
+  /// Build a cursor identifying [row].
+  C cursorOf(T row);
+
+  /// Build the request for the page after this one, given the [cursor] of
+  /// the last row in the current page.
+  PageRequest<T, C> withCursor(C cursor);
+}
+
+/// A single page of rows.
+final class Page<T extends Row, C extends Object> {
+  /// Rows in this page, ordered as specified by the [PageRequest].
+  final List<T> items;
+
+  /// Cursor identifying the row after which the next page begins, or `null`
+  /// if [items] is the last page of rows.
+  C? get nextCursor => nextPageRequest?.cursor;
+
+  /// A ready-to-use [PageRequest] for fetching the next [Page], or `null` if
+  /// [items] is the last page of rows.
+  final PageRequest<T, C>? nextPageRequest;
+
+  Page._(this.items, this.nextPageRequest);
+
+  /// `true` if there are more rows after this [Page].
+  bool get hasMore => nextCursor != null;
+}

--- a/typed_sql/pubspec.yaml
+++ b/typed_sql/pubspec.yaml
@@ -1,5 +1,5 @@
 name: typed_sql
-version: 0.1.13
+version: 0.1.14
 description: Package for doing SQL with some type safety.
 homepage: https://github.com/google/dart-neats/tree/master/typed_sql
 repository: https://github.com/google/dart-neats.git

--- a/typed_sql/test/sqlite/model.g.dart
+++ b/typed_sql/test/sqlite/model.g.dart
@@ -179,6 +179,66 @@ extension TableUserExt on Table<User> {
       $ForGeneratedCode.deleteSingle(byKey(userId), _$User._$table);
 }
 
+/// Pagination cursor referencing a row in [User].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class UserCursor {
+  const UserCursor({required this.userId});
+
+  final int userId;
+
+  @override
+  String toString() => 'UserCursor(userId: "$userId")';
+}
+
+/// Sort direction for each _primary key_ field of [User], used by
+/// `.fetchPage(...)`.
+final class UserDirection {
+  const UserDirection({this.userId = Order.ascending});
+
+  final Order userId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [User].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class UserPageRequest implements PageRequest<User, UserCursor> {
+  const UserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const UserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final UserCursor? cursor;
+
+  final UserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<User> user) => [
+    (user.userId, direction.userId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<User> user) => direction.userId == Order.ascending
+      ? user.userId > toExpr(cursor!.userId)
+      : user.userId < toExpr(cursor!.userId);
+
+  @override
+  UserCursor cursorOf(User user) => UserCursor(userId: user.userId);
+
+  @override
+  UserPageRequest withCursor(UserCursor cursor) =>
+      UserPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `users` table.
 extension QueryUserExt on Query<(Expr<User>,)> {
   /// Lookup a single row in `users` table using the _primary key_.
@@ -187,6 +247,30 @@ extension QueryUserExt on Query<(Expr<User>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<User>,)> byKey(int userId) =>
       where((user) => user.userId.equalsValue(userId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<User, UserCursor>? request =
+  ///     UserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [UserCursor].
+  Future<Page<User, UserCursor>> fetchPage(
+    PageRequest<User, UserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<User, UserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `users` table matching this [Query].
   ///
@@ -776,6 +860,71 @@ extension TablePackageExt on Table<Package> {
       $ForGeneratedCode.deleteSingle(byKey(packageName), _$Package._$table);
 }
 
+/// Pagination cursor referencing a row in [Package].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class PackageCursor {
+  const PackageCursor({required this.packageName});
+
+  final String packageName;
+
+  @override
+  String toString() => 'PackageCursor(packageName: "$packageName")';
+}
+
+/// Sort direction for each _primary key_ field of [Package], used by
+/// `.fetchPage(...)`.
+final class PackageDirection {
+  const PackageDirection({this.packageName = Order.ascending});
+
+  final Order packageName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Package].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class PackagePageRequest implements PageRequest<Package, PackageCursor> {
+  const PackagePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const PackageDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final PackageCursor? cursor;
+
+  final PackageDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Package> package) => [
+    (package.packageName, direction.packageName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Package> package) =>
+      direction.packageName == Order.ascending
+      ? package.packageName > toExpr(cursor!.packageName)
+      : package.packageName < toExpr(cursor!.packageName);
+
+  @override
+  PackageCursor cursorOf(Package package) =>
+      PackageCursor(packageName: package.packageName);
+
+  @override
+  PackagePageRequest withCursor(PackageCursor cursor) => PackagePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `packages` table.
 extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// Lookup a single row in `packages` table using the _primary key_.
@@ -784,6 +933,30 @@ extension QueryPackageExt on Query<(Expr<Package>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Package>,)> byKey(String packageName) =>
       where((package) => package.packageName.equalsValue(packageName)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Package, PackageCursor>? request =
+  ///     PackagePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [PackageCursor].
+  Future<Page<Package, PackageCursor>> fetchPage(
+    PageRequest<Package, PackageCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Package, PackageCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `packages` table matching this [Query].
   ///
@@ -1336,6 +1509,83 @@ extension TableLikeExt on Table<Like> {
       .deleteSingle(byKey(userId, packageName), _$Like._$table);
 }
 
+/// Pagination cursor referencing a row in [Like].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class LikeCursor {
+  const LikeCursor({required this.userId, required this.packageName});
+
+  final int userId;
+
+  final String packageName;
+
+  @override
+  String toString() =>
+      'LikeCursor(userId: "$userId", packageName: "$packageName")';
+}
+
+/// Sort direction for each _primary key_ field of [Like], used by
+/// `.fetchPage(...)`.
+final class LikeDirection {
+  const LikeDirection({
+    this.userId = Order.ascending,
+    this.packageName = Order.ascending,
+  });
+
+  final Order userId;
+
+  final Order packageName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Like].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class LikePageRequest implements PageRequest<Like, LikeCursor> {
+  const LikePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const LikeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final LikeCursor? cursor;
+
+  final LikeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Like> like) => [
+    (like.userId, direction.userId),
+    (like.packageName, direction.packageName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Like> like) =>
+      (direction.userId == Order.ascending
+              ? like.userId > toExpr(cursor!.userId)
+              : like.userId < toExpr(cursor!.userId))
+          .or(
+            like.userId.equalsValue(cursor!.userId) &
+                (direction.packageName == Order.ascending
+                    ? like.packageName > toExpr(cursor!.packageName)
+                    : like.packageName < toExpr(cursor!.packageName)),
+          );
+
+  @override
+  LikeCursor cursorOf(Like like) =>
+      LikeCursor(userId: like.userId, packageName: like.packageName);
+
+  @override
+  LikePageRequest withCursor(LikeCursor cursor) =>
+      LikePageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `likes` table.
 extension QueryLikeExt on Query<(Expr<Like>,)> {
   /// Lookup a single row in `likes` table using the _primary key_.
@@ -1347,6 +1597,30 @@ extension QueryLikeExt on Query<(Expr<Like>,)> {
         like.userId.equalsValue(userId) &
         like.packageName.equalsValue(packageName),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Like, LikeCursor>? request =
+  ///     LikePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [LikeCursor].
+  Future<Page<Like, LikeCursor>> fetchPage(
+    PageRequest<Like, LikeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Like, LikeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `likes` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
+++ b/typed_sql/test/typed_sql/aggregates/count_model/count_model_test.g.dart
@@ -209,6 +209,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -217,6 +277,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
+++ b/typed_sql/test/typed_sql/composite/unionall_null_model/unionall_null_model.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/blob/blob_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/boolean/boolean_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/datetime/datetime_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/integer/integer_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/json/json_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/json/json_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/real/real_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/real/real_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/crud/text/text_test.g.dart
+++ b/typed_sql/test/typed_sql/crud/text/text_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob/custom_blob_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_blob_alias/custom_blob_alias_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_boolean/custom_boolean_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_datetime/custom_datetime_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_integer/custom_integer_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json/custom_json_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_json_type/custom_json_type_test.g.dart
@@ -152,6 +152,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -160,6 +220,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_real/custom_real_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
+++ b/typed_sql/test/typed_sql/custom_types/custom_text/custom_text_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
+++ b/typed_sql/test/typed_sql/default/all_default_values/all_default_values_test.g.dart
@@ -209,6 +209,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -217,6 +277,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_date_time/default_date_time_test.g.dart
@@ -209,6 +209,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -217,6 +277,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_int_for_double/default_int_for_double_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
+++ b/typed_sql/test/typed_sql/default/default_nullable_int/default_nullable_int_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
+++ b/typed_sql/test/typed_sql/default/int_cast_test/int_cast_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_boolean/default_boolean_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_integer/default_integer_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json/default_json_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json/default_json_test.g.dart
@@ -152,6 +152,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -160,6 +220,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json_nested_structures/default_json_nested_structures_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json_nested_structures/default_json_nested_structures_test.g.dart
@@ -168,6 +168,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -176,6 +236,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_json_single_quote/default_json_single_quote_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_json_single_quote/default_json_single_quote_test.g.dart
@@ -152,6 +152,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -160,6 +220,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_nullable_text/default_nullable_text_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_real/default_real_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_text/default_text_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
+++ b/typed_sql/test/typed_sql/default/types/default_zero_real/default_zero_real_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
+++ b/typed_sql/test/typed_sql/distinct/distinct_model_null/distinct_model_null_test.g.dart
@@ -203,6 +203,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -211,6 +271,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
+++ b/typed_sql/test/typed_sql/documentation/model_documentation_test.g.dart
@@ -186,6 +186,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -194,6 +259,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -881,6 +970,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -889,6 +1038,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bank/bank_test.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
+++ b/typed_sql/test/typed_sql/example/blog/blog_test.g.dart
@@ -188,6 +188,82 @@ extension TablePostExt on Table<Post> {
       $ForGeneratedCode.deleteSingle(byKey(author, slug), _$Post._$table);
 }
 
+/// Pagination cursor referencing a row in [Post].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class PostCursor {
+  const PostCursor({required this.author, required this.slug});
+
+  final String author;
+
+  final String slug;
+
+  @override
+  String toString() => 'PostCursor(author: "$author", slug: "$slug")';
+}
+
+/// Sort direction for each _primary key_ field of [Post], used by
+/// `.fetchPage(...)`.
+final class PostDirection {
+  const PostDirection({
+    this.author = Order.ascending,
+    this.slug = Order.ascending,
+  });
+
+  final Order author;
+
+  final Order slug;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Post].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class PostPageRequest implements PageRequest<Post, PostCursor> {
+  const PostPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const PostDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final PostCursor? cursor;
+
+  final PostDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Post> post) => [
+    (post.author, direction.author),
+    (post.slug, direction.slug),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Post> post) =>
+      (direction.author == Order.ascending
+              ? post.author > toExpr(cursor!.author)
+              : post.author < toExpr(cursor!.author))
+          .or(
+            post.author.equalsValue(cursor!.author) &
+                (direction.slug == Order.ascending
+                    ? post.slug > toExpr(cursor!.slug)
+                    : post.slug < toExpr(cursor!.slug)),
+          );
+
+  @override
+  PostCursor cursorOf(Post post) =>
+      PostCursor(author: post.author, slug: post.slug);
+
+  @override
+  PostPageRequest withCursor(PostCursor cursor) =>
+      PostPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `posts` table.
 extension QueryPostExt on Query<(Expr<Post>,)> {
   /// Lookup a single row in `posts` table using the _primary key_.
@@ -197,6 +273,30 @@ extension QueryPostExt on Query<(Expr<Post>,)> {
   QuerySingle<(Expr<Post>,)> byKey(String author, String slug) => where(
     (post) => post.author.equalsValue(author) & post.slug.equalsValue(slug),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Post, PostCursor>? request =
+  ///     PostPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [PostCursor].
+  Future<Page<Post, PostCursor>> fetchPage(
+    PageRequest<Post, PostCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Post, PostCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `posts` table matching this [Query].
   ///
@@ -774,6 +874,71 @@ extension TableCommentExt on Table<Comment> {
       $ForGeneratedCode.deleteSingle(byKey(commentId), _$Comment._$table);
 }
 
+/// Pagination cursor referencing a row in [Comment].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CommentCursor {
+  const CommentCursor({required this.commentId});
+
+  final int commentId;
+
+  @override
+  String toString() => 'CommentCursor(commentId: "$commentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Comment], used by
+/// `.fetchPage(...)`.
+final class CommentDirection {
+  const CommentDirection({this.commentId = Order.ascending});
+
+  final Order commentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Comment].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CommentPageRequest implements PageRequest<Comment, CommentCursor> {
+  const CommentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CommentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CommentCursor? cursor;
+
+  final CommentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Comment> comment) => [
+    (comment.commentId, direction.commentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Comment> comment) =>
+      direction.commentId == Order.ascending
+      ? comment.commentId > toExpr(cursor!.commentId)
+      : comment.commentId < toExpr(cursor!.commentId);
+
+  @override
+  CommentCursor cursorOf(Comment comment) =>
+      CommentCursor(commentId: comment.commentId);
+
+  @override
+  CommentPageRequest withCursor(CommentCursor cursor) => CommentPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `comments` table.
 extension QueryCommentExt on Query<(Expr<Comment>,)> {
   /// Lookup a single row in `comments` table using the _primary key_.
@@ -782,6 +947,30 @@ extension QueryCommentExt on Query<(Expr<Comment>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Comment>,)> byKey(int commentId) =>
       where((comment) => comment.commentId.equalsValue(commentId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Comment, CommentCursor>? request =
+  ///     CommentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CommentCursor].
+  Future<Page<Comment, CommentCursor>> fetchPage(
+    PageRequest<Comment, CommentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Comment, CommentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `comments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
+++ b/typed_sql/test/typed_sql/example/bookstore/bookstore_test.g.dart
@@ -163,6 +163,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -171,6 +236,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -714,6 +803,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -722,6 +871,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/company/company_test.g.dart
+++ b/typed_sql/test/typed_sql/example/company/company_test.g.dart
@@ -178,6 +178,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.departmentId});
+
+  final int departmentId;
+
+  @override
+  String toString() => 'DepartmentCursor(departmentId: "$departmentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.departmentId = Order.ascending});
+
+  final Order departmentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.departmentId, direction.departmentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.departmentId == Order.ascending
+      ? department.departmentId > toExpr(cursor!.departmentId)
+      : department.departmentId < toExpr(cursor!.departmentId);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(departmentId: department.departmentId);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -187,6 +254,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
     (department) => department.departmentId.equalsValue(departmentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///
@@ -735,6 +826,72 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.employeeId});
+
+  final int employeeId;
+
+  @override
+  String toString() => 'EmployeeCursor(employeeId: "$employeeId")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.employeeId = Order.ascending});
+
+  final Order employeeId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.employeeId, direction.employeeId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) =>
+      direction.employeeId == Order.ascending
+      ? employee.employeeId > toExpr(cursor!.employeeId)
+      : employee.employeeId < toExpr(cursor!.employeeId);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) =>
+      EmployeeCursor(employeeId: employee.employeeId);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -743,6 +900,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
       where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
+++ b/typed_sql/test/typed_sql/example/dealership/dealership_test.g.dart
@@ -197,6 +197,66 @@ extension TableCarExt on Table<Car> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Car._$table);
 }
 
+/// Pagination cursor referencing a row in [Car].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CarCursor {
+  const CarCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'CarCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Car], used by
+/// `.fetchPage(...)`.
+final class CarDirection {
+  const CarDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Car].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CarPageRequest implements PageRequest<Car, CarCursor> {
+  const CarPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CarDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CarCursor? cursor;
+
+  final CarDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Car> car) => [
+    (car.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Car> car) => direction.id == Order.ascending
+      ? car.id > toExpr(cursor!.id)
+      : car.id < toExpr(cursor!.id);
+
+  @override
+  CarCursor cursorOf(Car car) => CarCursor(id: car.id);
+
+  @override
+  CarPageRequest withCursor(CarCursor cursor) =>
+      CarPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `cars` table.
 extension QueryCarExt on Query<(Expr<Car>,)> {
   /// Lookup a single row in `cars` table using the _primary key_.
@@ -205,6 +265,29 @@ extension QueryCarExt on Query<(Expr<Car>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Car>,)> byKey(int id) =>
       where((car) => car.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Car, CarCursor>? request =
+  ///     CarPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CarCursor].
+  Future<Page<Car, CarCursor>> fetchPage(PageRequest<Car, CarCursor> request) =>
+      $ForGeneratedCode.fetchPage<Car, CarCursor>(
+        query: this,
+        request: request,
+      );
 
   /// Update all rows in the `cars` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/model.g.dart
@@ -167,6 +167,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -175,6 +240,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
+++ b/typed_sql/test/typed_sql/example/migration/lib/patched_model.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/schema/schema_default_value/schema_default_value_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_default_value/schema_default_value_test.g.dart
@@ -163,6 +163,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -171,6 +236,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -714,6 +803,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -722,6 +871,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/schema/schema_overrides/schema_overrides_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_overrides/schema_overrides_test.g.dart
@@ -170,6 +170,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -178,6 +243,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -721,6 +810,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `booksInStock` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `booksInStock` table using the _primary key_.
@@ -729,6 +878,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `booksInStock` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/schema/schema_references/schema_references_test.g.dart
+++ b/typed_sql/test/typed_sql/example/schema/schema_references/schema_references_test.g.dart
@@ -163,6 +163,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -171,6 +236,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -714,6 +803,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -722,6 +871,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/example/testing/model.g.dart
+++ b/typed_sql/test/typed_sql/example/testing/model.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/advanced_composite_fk/advanced_composite_fk_test.g.dart
@@ -188,6 +188,82 @@ extension TablePostExt on Table<Post> {
       $ForGeneratedCode.deleteSingle(byKey(author, slug), _$Post._$table);
 }
 
+/// Pagination cursor referencing a row in [Post].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class PostCursor {
+  const PostCursor({required this.author, required this.slug});
+
+  final String author;
+
+  final String slug;
+
+  @override
+  String toString() => 'PostCursor(author: "$author", slug: "$slug")';
+}
+
+/// Sort direction for each _primary key_ field of [Post], used by
+/// `.fetchPage(...)`.
+final class PostDirection {
+  const PostDirection({
+    this.author = Order.ascending,
+    this.slug = Order.ascending,
+  });
+
+  final Order author;
+
+  final Order slug;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Post].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class PostPageRequest implements PageRequest<Post, PostCursor> {
+  const PostPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const PostDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final PostCursor? cursor;
+
+  final PostDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Post> post) => [
+    (post.author, direction.author),
+    (post.slug, direction.slug),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Post> post) =>
+      (direction.author == Order.ascending
+              ? post.author > toExpr(cursor!.author)
+              : post.author < toExpr(cursor!.author))
+          .or(
+            post.author.equalsValue(cursor!.author) &
+                (direction.slug == Order.ascending
+                    ? post.slug > toExpr(cursor!.slug)
+                    : post.slug < toExpr(cursor!.slug)),
+          );
+
+  @override
+  PostCursor cursorOf(Post post) =>
+      PostCursor(author: post.author, slug: post.slug);
+
+  @override
+  PostPageRequest withCursor(PostCursor cursor) =>
+      PostPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `posts` table.
 extension QueryPostExt on Query<(Expr<Post>,)> {
   /// Lookup a single row in `posts` table using the _primary key_.
@@ -197,6 +273,30 @@ extension QueryPostExt on Query<(Expr<Post>,)> {
   QuerySingle<(Expr<Post>,)> byKey(String author, String slug) => where(
     (post) => post.author.equalsValue(author) & post.slug.equalsValue(slug),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Post, PostCursor>? request =
+  ///     PostPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [PostCursor].
+  Future<Page<Post, PostCursor>> fetchPage(
+    PageRequest<Post, PostCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Post, PostCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `posts` table matching this [Query].
   ///
@@ -774,6 +874,71 @@ extension TableCommentExt on Table<Comment> {
       $ForGeneratedCode.deleteSingle(byKey(commentId), _$Comment._$table);
 }
 
+/// Pagination cursor referencing a row in [Comment].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CommentCursor {
+  const CommentCursor({required this.commentId});
+
+  final int commentId;
+
+  @override
+  String toString() => 'CommentCursor(commentId: "$commentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Comment], used by
+/// `.fetchPage(...)`.
+final class CommentDirection {
+  const CommentDirection({this.commentId = Order.ascending});
+
+  final Order commentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Comment].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CommentPageRequest implements PageRequest<Comment, CommentCursor> {
+  const CommentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CommentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CommentCursor? cursor;
+
+  final CommentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Comment> comment) => [
+    (comment.commentId, direction.commentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Comment> comment) =>
+      direction.commentId == Order.ascending
+      ? comment.commentId > toExpr(cursor!.commentId)
+      : comment.commentId < toExpr(cursor!.commentId);
+
+  @override
+  CommentCursor cursorOf(Comment comment) =>
+      CommentCursor(commentId: comment.commentId);
+
+  @override
+  CommentPageRequest withCursor(CommentCursor cursor) => CommentPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `comments` table.
 extension QueryCommentExt on Query<(Expr<Comment>,)> {
   /// Lookup a single row in `comments` table using the _primary key_.
@@ -782,6 +947,30 @@ extension QueryCommentExt on Query<(Expr<Comment>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Comment>,)> byKey(int commentId) =>
       where((comment) => comment.commentId.equalsValue(commentId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Comment, CommentCursor>? request =
+  ///     CommentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CommentCursor].
+  Future<Page<Comment, CommentCursor>> fetchPage(
+    PageRequest<Comment, CommentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Comment, CommentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `comments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/composite_foreign_key/composite_foreign_key_test.g.dart
@@ -174,6 +174,86 @@ extension TableAuthorExt on Table<Author> {
       );
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.firstName, required this.lastName});
+
+  final String firstName;
+
+  final String lastName;
+
+  @override
+  String toString() =>
+      'AuthorCursor(firstName: "$firstName", lastName: "$lastName")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({
+    this.firstName = Order.ascending,
+    this.lastName = Order.ascending,
+  });
+
+  final Order firstName;
+
+  final Order lastName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.firstName, direction.firstName),
+    (author.lastName, direction.lastName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      (direction.firstName == Order.ascending
+              ? author.firstName > toExpr(cursor!.firstName)
+              : author.firstName < toExpr(cursor!.firstName))
+          .or(
+            author.firstName.equalsValue(cursor!.firstName) &
+                (direction.lastName == Order.ascending
+                    ? author.lastName > toExpr(cursor!.lastName)
+                    : author.lastName < toExpr(cursor!.lastName)),
+          );
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(firstName: author.firstName, lastName: author.lastName);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -186,6 +266,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
             author.firstName.equalsValue(firstName) &
             author.lastName.equalsValue(lastName),
       ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -784,6 +888,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -792,6 +956,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/nullable_composite_foreign_key/nullable_composite_foreign_key_test.g.dart
@@ -174,6 +174,86 @@ extension TableAuthorExt on Table<Author> {
       );
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.firstName, required this.lastName});
+
+  final String firstName;
+
+  final String lastName;
+
+  @override
+  String toString() =>
+      'AuthorCursor(firstName: "$firstName", lastName: "$lastName")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({
+    this.firstName = Order.ascending,
+    this.lastName = Order.ascending,
+  });
+
+  final Order firstName;
+
+  final Order lastName;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.firstName, direction.firstName),
+    (author.lastName, direction.lastName),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      (direction.firstName == Order.ascending
+              ? author.firstName > toExpr(cursor!.firstName)
+              : author.firstName < toExpr(cursor!.firstName))
+          .or(
+            author.firstName.equalsValue(cursor!.firstName) &
+                (direction.lastName == Order.ascending
+                    ? author.lastName > toExpr(cursor!.lastName)
+                    : author.lastName < toExpr(cursor!.lastName)),
+          );
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(firstName: author.firstName, lastName: author.lastName);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -186,6 +266,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
             author.firstName.equalsValue(firstName) &
             author.lastName.equalsValue(lastName),
       ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -784,6 +888,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -792,6 +956,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_cascade_foreign_key_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_no_action_foreign_key_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_restrict_foreign_key_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/on_referential_event_foreign_key/on_referential_event_set_nulls_foreign_key_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
+++ b/typed_sql/test/typed_sql/foreign_key/simple_foreign_key/simple_foreign_key_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_bugs/group_by_bugs_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_bugs/group_by_bugs_test.g.dart
@@ -185,6 +185,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -193,6 +253,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_composite/group_by_composite_test.g.dart
@@ -365,6 +365,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -373,6 +433,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_expression/group_by_expression_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_expression/group_by_expression_test.g.dart
@@ -170,6 +170,70 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'EmployeeCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) => direction.id == Order.ascending
+      ? employee.id > toExpr(cursor!.id)
+      : employee.id < toExpr(cursor!.id);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) => EmployeeCursor(id: employee.id);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -178,6 +242,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int id) =>
       where((employee) => employee.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_having/group_by_having_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_having/group_by_having_test.g.dart
@@ -170,6 +170,70 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'EmployeeCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) => direction.id == Order.ascending
+      ? employee.id > toExpr(cursor!.id)
+      : employee.id < toExpr(cursor!.id);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) => EmployeeCursor(id: employee.id);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -178,6 +242,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int id) =>
       where((employee) => employee.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_join_complex/complex_aggregations_test.g.dart
@@ -175,6 +175,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.departmentId});
+
+  final int departmentId;
+
+  @override
+  String toString() => 'DepartmentCursor(departmentId: "$departmentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.departmentId = Order.ascending});
+
+  final Order departmentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.departmentId, direction.departmentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.departmentId == Order.ascending
+      ? department.departmentId > toExpr(cursor!.departmentId)
+      : department.departmentId < toExpr(cursor!.departmentId);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(departmentId: department.departmentId);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -184,6 +251,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
     (department) => department.departmentId.equalsValue(departmentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///
@@ -655,6 +746,72 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.employeeId});
+
+  final int employeeId;
+
+  @override
+  String toString() => 'EmployeeCursor(employeeId: "$employeeId")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.employeeId = Order.ascending});
+
+  final Order employeeId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.employeeId, direction.employeeId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) =>
+      direction.employeeId == Order.ascending
+      ? employee.employeeId > toExpr(cursor!.employeeId)
+      : employee.employeeId < toExpr(cursor!.employeeId);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) =>
+      EmployeeCursor(employeeId: employee.employeeId);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -663,6 +820,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
       where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///
@@ -1182,6 +1363,71 @@ extension TableProjectExt on Table<Project> {
       $ForGeneratedCode.deleteSingle(byKey(projectId), _$Project._$table);
 }
 
+/// Pagination cursor referencing a row in [Project].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ProjectCursor {
+  const ProjectCursor({required this.projectId});
+
+  final int projectId;
+
+  @override
+  String toString() => 'ProjectCursor(projectId: "$projectId")';
+}
+
+/// Sort direction for each _primary key_ field of [Project], used by
+/// `.fetchPage(...)`.
+final class ProjectDirection {
+  const ProjectDirection({this.projectId = Order.ascending});
+
+  final Order projectId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Project].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ProjectPageRequest implements PageRequest<Project, ProjectCursor> {
+  const ProjectPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ProjectDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ProjectCursor? cursor;
+
+  final ProjectDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Project> project) => [
+    (project.projectId, direction.projectId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Project> project) =>
+      direction.projectId == Order.ascending
+      ? project.projectId > toExpr(cursor!.projectId)
+      : project.projectId < toExpr(cursor!.projectId);
+
+  @override
+  ProjectCursor cursorOf(Project project) =>
+      ProjectCursor(projectId: project.projectId);
+
+  @override
+  ProjectPageRequest withCursor(ProjectCursor cursor) => ProjectPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `projects` table.
 extension QueryProjectExt on Query<(Expr<Project>,)> {
   /// Lookup a single row in `projects` table using the _primary key_.
@@ -1190,6 +1436,30 @@ extension QueryProjectExt on Query<(Expr<Project>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Project>,)> byKey(int projectId) =>
       where((project) => project.projectId.equalsValue(projectId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Project, ProjectCursor>? request =
+  ///     ProjectPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ProjectCursor].
+  Future<Page<Project, ProjectCursor>> fetchPage(
+    PageRequest<Project, ProjectCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Project, ProjectCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `projects` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_join_expression/group_by_join_expression_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_join_expression/group_by_join_expression_test.g.dart
@@ -155,6 +155,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'DepartmentCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.id == Order.ascending
+      ? department.id > toExpr(cursor!.id)
+      : department.id < toExpr(cursor!.id);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(id: department.id);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -163,6 +230,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Department>,)> byKey(int id) =>
       where((department) => department.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///
@@ -632,6 +723,70 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'EmployeeCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) => direction.id == Order.ascending
+      ? employee.id > toExpr(cursor!.id)
+      : employee.id < toExpr(cursor!.id);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) => EmployeeCursor(id: employee.id);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -640,6 +795,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int id) =>
       where((employee) => employee.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_json/json_groupby_caveat_test.g.dart
@@ -169,6 +169,69 @@ extension TableProductExt on Table<Product> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
 }
 
+/// Pagination cursor referencing a row in [Product].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ProductCursor {
+  const ProductCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ProductCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Product], used by
+/// `.fetchPage(...)`.
+final class ProductDirection {
+  const ProductDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Product].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ProductPageRequest implements PageRequest<Product, ProductCursor> {
+  const ProductPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ProductDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ProductCursor? cursor;
+
+  final ProductDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Product> product) => [
+    (product.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Product> product) => direction.id == Order.ascending
+      ? product.id > toExpr(cursor!.id)
+      : product.id < toExpr(cursor!.id);
+
+  @override
+  ProductCursor cursorOf(Product product) => ProductCursor(id: product.id);
+
+  @override
+  ProductPageRequest withCursor(ProductCursor cursor) => ProductPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `products` table.
 extension QueryProductExt on Query<(Expr<Product>,)> {
   /// Lookup a single row in `products` table using the _primary key_.
@@ -177,6 +240,30 @@ extension QueryProductExt on Query<(Expr<Product>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Product>,)> byKey(int id) =>
       where((product) => product.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Product, ProductCursor>? request =
+  ///     ProductPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ProductCursor].
+  Future<Page<Product, ProductCursor>> fetchPage(
+    PageRequest<Product, ProductCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Product, ProductCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `products` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_null/group_by_null_test.g.dart
@@ -186,6 +186,70 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'EmployeeCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) => direction.id == Order.ascending
+      ? employee.id > toExpr(cursor!.id)
+      : employee.id < toExpr(cursor!.id);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) => EmployeeCursor(id: employee.id);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -194,6 +258,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int id) =>
       where((employee) => employee.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_reference/group_by_reference_test.g.dart
@@ -154,6 +154,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -162,6 +227,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -677,6 +766,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -685,6 +834,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
+++ b/typed_sql/test/typed_sql/group_by/group_by_string/group_by_string_test.g.dart
@@ -186,6 +186,70 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'EmployeeCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) => direction.id == Order.ascending
+      ? employee.id > toExpr(cursor!.id)
+      : employee.id < toExpr(cursor!.id);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) => EmployeeCursor(id: employee.id);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -194,6 +258,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int id) =>
       where((employee) => employee.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/all_types/all_types_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/all_types/all_types_test.g.dart
@@ -627,6 +627,73 @@ extension TableAllTypesItemExt on Table<AllTypesItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$AllTypesItem._$table);
 }
 
+/// Pagination cursor referencing a row in [AllTypesItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AllTypesItemCursor {
+  const AllTypesItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'AllTypesItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [AllTypesItem], used by
+/// `.fetchPage(...)`.
+final class AllTypesItemDirection {
+  const AllTypesItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [AllTypesItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AllTypesItemPageRequest
+    implements PageRequest<AllTypesItem, AllTypesItemCursor> {
+  const AllTypesItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AllTypesItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AllTypesItemCursor? cursor;
+
+  final AllTypesItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<AllTypesItem> allTypesItem) => [
+    (allTypesItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<AllTypesItem> allTypesItem) =>
+      direction.id == Order.ascending
+      ? allTypesItem.id > toExpr(cursor!.id)
+      : allTypesItem.id < toExpr(cursor!.id);
+
+  @override
+  AllTypesItemCursor cursorOf(AllTypesItem allTypesItem) =>
+      AllTypesItemCursor(id: allTypesItem.id);
+
+  @override
+  AllTypesItemPageRequest withCursor(AllTypesItemCursor cursor) =>
+      AllTypesItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `allTypesItems` table.
 extension QueryAllTypesItemExt on Query<(Expr<AllTypesItem>,)> {
   /// Lookup a single row in `allTypesItems` table using the _primary key_.
@@ -635,6 +702,30 @@ extension QueryAllTypesItemExt on Query<(Expr<AllTypesItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<AllTypesItem>,)> byKey(int id) =>
       where((allTypesItem) => allTypesItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<AllTypesItem, AllTypesItemCursor>? request =
+  ///     AllTypesItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AllTypesItemCursor].
+  Future<Page<AllTypesItem, AllTypesItemCursor>> fetchPage(
+    PageRequest<AllTypesItem, AllTypesItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<AllTypesItem, AllTypesItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `allTypesItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/complex_constraints/complex_constraints_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/complex_constraints/complex_constraints_test.g.dart
@@ -190,6 +190,89 @@ extension TableCompositePkItemExt on Table<CompositePkItem> {
       .deleteSingle(byKey(pkA, pkB), _$CompositePkItem._$table);
 }
 
+/// Pagination cursor referencing a row in [CompositePkItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CompositePkItemCursor {
+  const CompositePkItemCursor({required this.pkA, required this.pkB});
+
+  final int pkA;
+
+  final String pkB;
+
+  @override
+  String toString() => 'CompositePkItemCursor(pkA: "$pkA", pkB: "$pkB")';
+}
+
+/// Sort direction for each _primary key_ field of [CompositePkItem], used by
+/// `.fetchPage(...)`.
+final class CompositePkItemDirection {
+  const CompositePkItemDirection({
+    this.pkA = Order.ascending,
+    this.pkB = Order.ascending,
+  });
+
+  final Order pkA;
+
+  final Order pkB;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [CompositePkItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CompositePkItemPageRequest
+    implements PageRequest<CompositePkItem, CompositePkItemCursor> {
+  const CompositePkItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CompositePkItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CompositePkItemCursor? cursor;
+
+  final CompositePkItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<CompositePkItem> compositePkItem,
+  ) => [
+    (compositePkItem.pkA, direction.pkA),
+    (compositePkItem.pkB, direction.pkB),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<CompositePkItem> compositePkItem) =>
+      (direction.pkA == Order.ascending
+              ? compositePkItem.pkA > toExpr(cursor!.pkA)
+              : compositePkItem.pkA < toExpr(cursor!.pkA))
+          .or(
+            compositePkItem.pkA.equalsValue(cursor!.pkA) &
+                (direction.pkB == Order.ascending
+                    ? compositePkItem.pkB > toExpr(cursor!.pkB)
+                    : compositePkItem.pkB < toExpr(cursor!.pkB)),
+          );
+
+  @override
+  CompositePkItemCursor cursorOf(CompositePkItem compositePkItem) =>
+      CompositePkItemCursor(pkA: compositePkItem.pkA, pkB: compositePkItem.pkB);
+
+  @override
+  CompositePkItemPageRequest withCursor(CompositePkItemCursor cursor) =>
+      CompositePkItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `compositePkItems` table.
 extension QueryCompositePkItemExt on Query<(Expr<CompositePkItem>,)> {
   /// Lookup a single row in `compositePkItems` table using the _primary key_.
@@ -201,6 +284,30 @@ extension QueryCompositePkItemExt on Query<(Expr<CompositePkItem>,)> {
         compositePkItem.pkA.equalsValue(pkA) &
         compositePkItem.pkB.equalsValue(pkB),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<CompositePkItem, CompositePkItemCursor>? request =
+  ///     CompositePkItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CompositePkItemCursor].
+  Future<Page<CompositePkItem, CompositePkItemCursor>> fetchPage(
+    PageRequest<CompositePkItem, CompositePkItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<CompositePkItem, CompositePkItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `compositePkItems` table matching this [Query].
   ///
@@ -700,6 +807,73 @@ extension TableMultiUniqueItemExt on Table<MultiUniqueItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$MultiUniqueItem._$table);
 }
 
+/// Pagination cursor referencing a row in [MultiUniqueItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class MultiUniqueItemCursor {
+  const MultiUniqueItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'MultiUniqueItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [MultiUniqueItem], used by
+/// `.fetchPage(...)`.
+final class MultiUniqueItemDirection {
+  const MultiUniqueItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [MultiUniqueItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class MultiUniqueItemPageRequest
+    implements PageRequest<MultiUniqueItem, MultiUniqueItemCursor> {
+  const MultiUniqueItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const MultiUniqueItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final MultiUniqueItemCursor? cursor;
+
+  final MultiUniqueItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<MultiUniqueItem> multiUniqueItem,
+  ) => [(multiUniqueItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<MultiUniqueItem> multiUniqueItem) =>
+      direction.id == Order.ascending
+      ? multiUniqueItem.id > toExpr(cursor!.id)
+      : multiUniqueItem.id < toExpr(cursor!.id);
+
+  @override
+  MultiUniqueItemCursor cursorOf(MultiUniqueItem multiUniqueItem) =>
+      MultiUniqueItemCursor(id: multiUniqueItem.id);
+
+  @override
+  MultiUniqueItemPageRequest withCursor(MultiUniqueItemCursor cursor) =>
+      MultiUniqueItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `multiUniqueItems` table.
 extension QueryMultiUniqueItemExt on Query<(Expr<MultiUniqueItem>,)> {
   /// Lookup a single row in `multiUniqueItems` table using the _primary key_.
@@ -708,6 +882,30 @@ extension QueryMultiUniqueItemExt on Query<(Expr<MultiUniqueItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<MultiUniqueItem>,)> byKey(int id) =>
       where((multiUniqueItem) => multiUniqueItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<MultiUniqueItem, MultiUniqueItemCursor>? request =
+  ///     MultiUniqueItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [MultiUniqueItemCursor].
+  Future<Page<MultiUniqueItem, MultiUniqueItemCursor>> fetchPage(
+    PageRequest<MultiUniqueItem, MultiUniqueItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<MultiUniqueItem, MultiUniqueItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `multiUniqueItems` table matching this [Query].
   ///
@@ -1285,6 +1483,73 @@ extension TableForeignKeyItemExt on Table<ForeignKeyItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$ForeignKeyItem._$table);
 }
 
+/// Pagination cursor referencing a row in [ForeignKeyItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ForeignKeyItemCursor {
+  const ForeignKeyItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ForeignKeyItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [ForeignKeyItem], used by
+/// `.fetchPage(...)`.
+final class ForeignKeyItemDirection {
+  const ForeignKeyItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ForeignKeyItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ForeignKeyItemPageRequest
+    implements PageRequest<ForeignKeyItem, ForeignKeyItemCursor> {
+  const ForeignKeyItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ForeignKeyItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ForeignKeyItemCursor? cursor;
+
+  final ForeignKeyItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<ForeignKeyItem> foreignKeyItem,
+  ) => [(foreignKeyItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<ForeignKeyItem> foreignKeyItem) =>
+      direction.id == Order.ascending
+      ? foreignKeyItem.id > toExpr(cursor!.id)
+      : foreignKeyItem.id < toExpr(cursor!.id);
+
+  @override
+  ForeignKeyItemCursor cursorOf(ForeignKeyItem foreignKeyItem) =>
+      ForeignKeyItemCursor(id: foreignKeyItem.id);
+
+  @override
+  ForeignKeyItemPageRequest withCursor(ForeignKeyItemCursor cursor) =>
+      ForeignKeyItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `foreignKeyItems` table.
 extension QueryForeignKeyItemExt on Query<(Expr<ForeignKeyItem>,)> {
   /// Lookup a single row in `foreignKeyItems` table using the _primary key_.
@@ -1293,6 +1558,30 @@ extension QueryForeignKeyItemExt on Query<(Expr<ForeignKeyItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<ForeignKeyItem>,)> byKey(int id) =>
       where((foreignKeyItem) => foreignKeyItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ForeignKeyItem, ForeignKeyItemCursor>? request =
+  ///     ForeignKeyItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ForeignKeyItemCursor].
+  Future<Page<ForeignKeyItem, ForeignKeyItemCursor>> fetchPage(
+    PageRequest<ForeignKeyItem, ForeignKeyItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<ForeignKeyItem, ForeignKeyItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `foreignKeyItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/defaults/defaults_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/defaults/defaults_test.g.dart
@@ -270,6 +270,73 @@ extension TableDefaultsItemExt on Table<DefaultsItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$DefaultsItem._$table);
 }
 
+/// Pagination cursor referencing a row in [DefaultsItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DefaultsItemCursor {
+  const DefaultsItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'DefaultsItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [DefaultsItem], used by
+/// `.fetchPage(...)`.
+final class DefaultsItemDirection {
+  const DefaultsItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [DefaultsItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DefaultsItemPageRequest
+    implements PageRequest<DefaultsItem, DefaultsItemCursor> {
+  const DefaultsItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DefaultsItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DefaultsItemCursor? cursor;
+
+  final DefaultsItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<DefaultsItem> defaultsItem) => [
+    (defaultsItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<DefaultsItem> defaultsItem) =>
+      direction.id == Order.ascending
+      ? defaultsItem.id > toExpr(cursor!.id)
+      : defaultsItem.id < toExpr(cursor!.id);
+
+  @override
+  DefaultsItemCursor cursorOf(DefaultsItem defaultsItem) =>
+      DefaultsItemCursor(id: defaultsItem.id);
+
+  @override
+  DefaultsItemPageRequest withCursor(DefaultsItemCursor cursor) =>
+      DefaultsItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `defaultsItems` table.
 extension QueryDefaultsItemExt on Query<(Expr<DefaultsItem>,)> {
   /// Lookup a single row in `defaultsItems` table using the _primary key_.
@@ -278,6 +345,30 @@ extension QueryDefaultsItemExt on Query<(Expr<DefaultsItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<DefaultsItem>,)> byKey(int id) =>
       where((defaultsItem) => defaultsItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<DefaultsItem, DefaultsItemCursor>? request =
+  ///     DefaultsItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DefaultsItemCursor].
+  Future<Page<DefaultsItem, DefaultsItemCursor>> fetchPage(
+    PageRequest<DefaultsItem, DefaultsItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<DefaultsItem, DefaultsItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `defaultsItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/insert_value/insert_value_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/insert_value/insert_value_test.g.dart
@@ -152,6 +152,73 @@ extension TableValueItemExt on Table<ValueItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$ValueItem._$table);
 }
 
+/// Pagination cursor referencing a row in [ValueItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ValueItemCursor {
+  const ValueItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ValueItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [ValueItem], used by
+/// `.fetchPage(...)`.
+final class ValueItemDirection {
+  const ValueItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ValueItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ValueItemPageRequest
+    implements PageRequest<ValueItem, ValueItemCursor> {
+  const ValueItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ValueItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ValueItemCursor? cursor;
+
+  final ValueItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<ValueItem> valueItem) => [
+    (valueItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<ValueItem> valueItem) =>
+      direction.id == Order.ascending
+      ? valueItem.id > toExpr(cursor!.id)
+      : valueItem.id < toExpr(cursor!.id);
+
+  @override
+  ValueItemCursor cursorOf(ValueItem valueItem) =>
+      ValueItemCursor(id: valueItem.id);
+
+  @override
+  ValueItemPageRequest withCursor(ValueItemCursor cursor) =>
+      ValueItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `valueItems` table.
 extension QueryValueItemExt on Query<(Expr<ValueItem>,)> {
   /// Lookup a single row in `valueItems` table using the _primary key_.
@@ -160,6 +227,30 @@ extension QueryValueItemExt on Query<(Expr<ValueItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<ValueItem>,)> byKey(int id) =>
       where((valueItem) => valueItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ValueItem, ValueItemCursor>? request =
+  ///     ValueItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ValueItemCursor].
+  Future<Page<ValueItem, ValueItemCursor>> fetchPage(
+    PageRequest<ValueItem, ValueItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<ValueItem, ValueItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `valueItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/insert_values_mapped/insert_values_mapped_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/insert_values_mapped/insert_values_mapped_test.g.dart
@@ -186,6 +186,73 @@ extension TableMappedItemExt on Table<MappedItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$MappedItem._$table);
 }
 
+/// Pagination cursor referencing a row in [MappedItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class MappedItemCursor {
+  const MappedItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'MappedItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [MappedItem], used by
+/// `.fetchPage(...)`.
+final class MappedItemDirection {
+  const MappedItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [MappedItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class MappedItemPageRequest
+    implements PageRequest<MappedItem, MappedItemCursor> {
+  const MappedItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const MappedItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final MappedItemCursor? cursor;
+
+  final MappedItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<MappedItem> mappedItem) => [
+    (mappedItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<MappedItem> mappedItem) =>
+      direction.id == Order.ascending
+      ? mappedItem.id > toExpr(cursor!.id)
+      : mappedItem.id < toExpr(cursor!.id);
+
+  @override
+  MappedItemCursor cursorOf(MappedItem mappedItem) =>
+      MappedItemCursor(id: mappedItem.id);
+
+  @override
+  MappedItemPageRequest withCursor(MappedItemCursor cursor) =>
+      MappedItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `mappedItems` table.
 extension QueryMappedItemExt on Query<(Expr<MappedItem>,)> {
   /// Lookup a single row in `mappedItems` table using the _primary key_.
@@ -194,6 +261,30 @@ extension QueryMappedItemExt on Query<(Expr<MappedItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<MappedItem>,)> byKey(int id) =>
       where((mappedItem) => mappedItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<MappedItem, MappedItemCursor>? request =
+  ///     MappedItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [MappedItemCursor].
+  Future<Page<MappedItem, MappedItemCursor>> fetchPage(
+    PageRequest<MappedItem, MappedItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<MappedItem, MappedItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `mappedItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/insert_values_mapped_complex/insert_values_mapped_complex_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/insert_values_mapped_complex/insert_values_mapped_complex_test.g.dart
@@ -264,6 +264,73 @@ extension TableComplexMappedItemExt on Table<ComplexMappedItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$ComplexMappedItem._$table);
 }
 
+/// Pagination cursor referencing a row in [ComplexMappedItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ComplexMappedItemCursor {
+  const ComplexMappedItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ComplexMappedItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [ComplexMappedItem], used by
+/// `.fetchPage(...)`.
+final class ComplexMappedItemDirection {
+  const ComplexMappedItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ComplexMappedItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ComplexMappedItemPageRequest
+    implements PageRequest<ComplexMappedItem, ComplexMappedItemCursor> {
+  const ComplexMappedItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ComplexMappedItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ComplexMappedItemCursor? cursor;
+
+  final ComplexMappedItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<ComplexMappedItem> complexMappedItem,
+  ) => [(complexMappedItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<ComplexMappedItem> complexMappedItem) =>
+      direction.id == Order.ascending
+      ? complexMappedItem.id > toExpr(cursor!.id)
+      : complexMappedItem.id < toExpr(cursor!.id);
+
+  @override
+  ComplexMappedItemCursor cursorOf(ComplexMappedItem complexMappedItem) =>
+      ComplexMappedItemCursor(id: complexMappedItem.id);
+
+  @override
+  ComplexMappedItemPageRequest withCursor(ComplexMappedItemCursor cursor) =>
+      ComplexMappedItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `complexMappedItems` table.
 extension QueryComplexMappedItemExt on Query<(Expr<ComplexMappedItem>,)> {
   /// Lookup a single row in `complexMappedItems` table using the _primary key_.
@@ -272,6 +339,30 @@ extension QueryComplexMappedItemExt on Query<(Expr<ComplexMappedItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<ComplexMappedItem>,)> byKey(int id) =>
       where((complexMappedItem) => complexMappedItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ComplexMappedItem, ComplexMappedItemCursor>? request =
+  ///     ComplexMappedItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ComplexMappedItemCursor].
+  Future<Page<ComplexMappedItem, ComplexMappedItemCursor>> fetchPage(
+    PageRequest<ComplexMappedItem, ComplexMappedItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<ComplexMappedItem, ComplexMappedItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `complexMappedItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/insert_values_mapped_conflict/insert_values_mapped_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/insert_values_mapped_conflict/insert_values_mapped_conflict_test.g.dart
@@ -184,6 +184,73 @@ extension TableConflictMappedItemExt on Table<ConflictMappedItem> {
       .deleteSingle(byKey(complexId), _$ConflictMappedItem._$table);
 }
 
+/// Pagination cursor referencing a row in [ConflictMappedItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ConflictMappedItemCursor {
+  const ConflictMappedItemCursor({required this.complexId});
+
+  final int complexId;
+
+  @override
+  String toString() => 'ConflictMappedItemCursor(complexId: "$complexId")';
+}
+
+/// Sort direction for each _primary key_ field of [ConflictMappedItem], used by
+/// `.fetchPage(...)`.
+final class ConflictMappedItemDirection {
+  const ConflictMappedItemDirection({this.complexId = Order.ascending});
+
+  final Order complexId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ConflictMappedItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ConflictMappedItemPageRequest
+    implements PageRequest<ConflictMappedItem, ConflictMappedItemCursor> {
+  const ConflictMappedItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ConflictMappedItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ConflictMappedItemCursor? cursor;
+
+  final ConflictMappedItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<ConflictMappedItem> conflictMappedItem,
+  ) => [(conflictMappedItem.complexId, direction.complexId)];
+
+  @override
+  Expr<bool?> where(Expr<ConflictMappedItem> conflictMappedItem) =>
+      direction.complexId == Order.ascending
+      ? conflictMappedItem.complexId > toExpr(cursor!.complexId)
+      : conflictMappedItem.complexId < toExpr(cursor!.complexId);
+
+  @override
+  ConflictMappedItemCursor cursorOf(ConflictMappedItem conflictMappedItem) =>
+      ConflictMappedItemCursor(complexId: conflictMappedItem.complexId);
+
+  @override
+  ConflictMappedItemPageRequest withCursor(ConflictMappedItemCursor cursor) =>
+      ConflictMappedItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `conflictMappedItems` table.
 extension QueryConflictMappedItemExt on Query<(Expr<ConflictMappedItem>,)> {
   /// Lookup a single row in `conflictMappedItems` table using the _primary key_.
@@ -193,6 +260,31 @@ extension QueryConflictMappedItemExt on Query<(Expr<ConflictMappedItem>,)> {
   QuerySingle<(Expr<ConflictMappedItem>,)> byKey(int complexId) => where(
     (conflictMappedItem) => conflictMappedItem.complexId.equalsValue(complexId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ConflictMappedItem, ConflictMappedItemCursor>? request =
+  ///     ConflictMappedItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ConflictMappedItemCursor].
+  Future<Page<ConflictMappedItem, ConflictMappedItemCursor>> fetchPage(
+    PageRequest<ConflictMappedItem, ConflictMappedItemCursor> request,
+  ) =>
+      $ForGeneratedCode.fetchPage<ConflictMappedItem, ConflictMappedItemCursor>(
+        query: this,
+        request: request,
+      );
 
   /// Update all rows in the `conflictMappedItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/json_insert/json_insert_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/json_insert/json_insert_test.g.dart
@@ -155,6 +155,70 @@ extension TableJsonItemExt on Table<JsonItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$JsonItem._$table);
 }
 
+/// Pagination cursor referencing a row in [JsonItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class JsonItemCursor {
+  const JsonItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'JsonItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [JsonItem], used by
+/// `.fetchPage(...)`.
+final class JsonItemDirection {
+  const JsonItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [JsonItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class JsonItemPageRequest
+    implements PageRequest<JsonItem, JsonItemCursor> {
+  const JsonItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const JsonItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final JsonItemCursor? cursor;
+
+  final JsonItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<JsonItem> jsonItem) => [
+    (jsonItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<JsonItem> jsonItem) => direction.id == Order.ascending
+      ? jsonItem.id > toExpr(cursor!.id)
+      : jsonItem.id < toExpr(cursor!.id);
+
+  @override
+  JsonItemCursor cursorOf(JsonItem jsonItem) => JsonItemCursor(id: jsonItem.id);
+
+  @override
+  JsonItemPageRequest withCursor(JsonItemCursor cursor) => JsonItemPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `jsonItems` table.
 extension QueryJsonItemExt on Query<(Expr<JsonItem>,)> {
   /// Lookup a single row in `jsonItems` table using the _primary key_.
@@ -163,6 +227,30 @@ extension QueryJsonItemExt on Query<(Expr<JsonItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<JsonItem>,)> byKey(int id) =>
       where((jsonItem) => jsonItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<JsonItem, JsonItemCursor>? request =
+  ///     JsonItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [JsonItemCursor].
+  Future<Page<JsonItem, JsonItemCursor>> fetchPage(
+    PageRequest<JsonItem, JsonItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<JsonItem, JsonItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `jsonItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert/upsert_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert/upsert_test.g.dart
@@ -199,6 +199,73 @@ extension TableSimpleItemExt on Table<SimpleItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$SimpleItem._$table);
 }
 
+/// Pagination cursor referencing a row in [SimpleItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SimpleItemCursor {
+  const SimpleItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'SimpleItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [SimpleItem], used by
+/// `.fetchPage(...)`.
+final class SimpleItemDirection {
+  const SimpleItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SimpleItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SimpleItemPageRequest
+    implements PageRequest<SimpleItem, SimpleItemCursor> {
+  const SimpleItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SimpleItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SimpleItemCursor? cursor;
+
+  final SimpleItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SimpleItem> simpleItem) => [
+    (simpleItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SimpleItem> simpleItem) =>
+      direction.id == Order.ascending
+      ? simpleItem.id > toExpr(cursor!.id)
+      : simpleItem.id < toExpr(cursor!.id);
+
+  @override
+  SimpleItemCursor cursorOf(SimpleItem simpleItem) =>
+      SimpleItemCursor(id: simpleItem.id);
+
+  @override
+  SimpleItemPageRequest withCursor(SimpleItemCursor cursor) =>
+      SimpleItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `simpleItems` table.
 extension QuerySimpleItemExt on Query<(Expr<SimpleItem>,)> {
   /// Lookup a single row in `simpleItems` table using the _primary key_.
@@ -207,6 +274,30 @@ extension QuerySimpleItemExt on Query<(Expr<SimpleItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<SimpleItem>,)> byKey(int id) =>
       where((simpleItem) => simpleItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SimpleItem, SimpleItemCursor>? request =
+  ///     SimpleItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SimpleItemCursor].
+  Future<Page<SimpleItem, SimpleItemCursor>> fetchPage(
+    PageRequest<SimpleItem, SimpleItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SimpleItem, SimpleItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `simpleItems` table matching this [Query].
   ///
@@ -768,6 +859,91 @@ extension TableCompositeItemExt on Table<CompositeItem> {
       );
 }
 
+/// Pagination cursor referencing a row in [CompositeItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CompositeItemCursor {
+  const CompositeItemCursor({required this.partA, required this.partB});
+
+  final String partA;
+
+  final int partB;
+
+  @override
+  String toString() => 'CompositeItemCursor(partA: "$partA", partB: "$partB")';
+}
+
+/// Sort direction for each _primary key_ field of [CompositeItem], used by
+/// `.fetchPage(...)`.
+final class CompositeItemDirection {
+  const CompositeItemDirection({
+    this.partA = Order.ascending,
+    this.partB = Order.ascending,
+  });
+
+  final Order partA;
+
+  final Order partB;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [CompositeItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CompositeItemPageRequest
+    implements PageRequest<CompositeItem, CompositeItemCursor> {
+  const CompositeItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CompositeItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CompositeItemCursor? cursor;
+
+  final CompositeItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<CompositeItem> compositeItem) =>
+      [
+        (compositeItem.partA, direction.partA),
+        (compositeItem.partB, direction.partB),
+      ];
+
+  @override
+  Expr<bool?> where(Expr<CompositeItem> compositeItem) =>
+      (direction.partA == Order.ascending
+              ? compositeItem.partA > toExpr(cursor!.partA)
+              : compositeItem.partA < toExpr(cursor!.partA))
+          .or(
+            compositeItem.partA.equalsValue(cursor!.partA) &
+                (direction.partB == Order.ascending
+                    ? compositeItem.partB > toExpr(cursor!.partB)
+                    : compositeItem.partB < toExpr(cursor!.partB)),
+          );
+
+  @override
+  CompositeItemCursor cursorOf(CompositeItem compositeItem) =>
+      CompositeItemCursor(
+        partA: compositeItem.partA,
+        partB: compositeItem.partB,
+      );
+
+  @override
+  CompositeItemPageRequest withCursor(CompositeItemCursor cursor) =>
+      CompositeItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `compositeItems` table.
 extension QueryCompositeItemExt on Query<(Expr<CompositeItem>,)> {
   /// Lookup a single row in `compositeItems` table using the _primary key_.
@@ -779,6 +955,30 @@ extension QueryCompositeItemExt on Query<(Expr<CompositeItem>,)> {
         compositeItem.partA.equalsValue(partA) &
         compositeItem.partB.equalsValue(partB),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<CompositeItem, CompositeItemCursor>? request =
+  ///     CompositeItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CompositeItemCursor].
+  Future<Page<CompositeItem, CompositeItemCursor>> fetchPage(
+    PageRequest<CompositeItem, CompositeItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<CompositeItem, CompositeItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `compositeItems` table matching this [Query].
   ///
@@ -1350,6 +1550,73 @@ extension TableNullableUniqueItemExt on Table<NullableUniqueItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$NullableUniqueItem._$table);
 }
 
+/// Pagination cursor referencing a row in [NullableUniqueItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class NullableUniqueItemCursor {
+  const NullableUniqueItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'NullableUniqueItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [NullableUniqueItem], used by
+/// `.fetchPage(...)`.
+final class NullableUniqueItemDirection {
+  const NullableUniqueItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [NullableUniqueItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class NullableUniqueItemPageRequest
+    implements PageRequest<NullableUniqueItem, NullableUniqueItemCursor> {
+  const NullableUniqueItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const NullableUniqueItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final NullableUniqueItemCursor? cursor;
+
+  final NullableUniqueItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<NullableUniqueItem> nullableUniqueItem,
+  ) => [(nullableUniqueItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<NullableUniqueItem> nullableUniqueItem) =>
+      direction.id == Order.ascending
+      ? nullableUniqueItem.id > toExpr(cursor!.id)
+      : nullableUniqueItem.id < toExpr(cursor!.id);
+
+  @override
+  NullableUniqueItemCursor cursorOf(NullableUniqueItem nullableUniqueItem) =>
+      NullableUniqueItemCursor(id: nullableUniqueItem.id);
+
+  @override
+  NullableUniqueItemPageRequest withCursor(NullableUniqueItemCursor cursor) =>
+      NullableUniqueItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `nullableUniqueItems` table.
 extension QueryNullableUniqueItemExt on Query<(Expr<NullableUniqueItem>,)> {
   /// Lookup a single row in `nullableUniqueItems` table using the _primary key_.
@@ -1359,6 +1626,31 @@ extension QueryNullableUniqueItemExt on Query<(Expr<NullableUniqueItem>,)> {
   QuerySingle<(Expr<NullableUniqueItem>,)> byKey(int id) => where(
     (nullableUniqueItem) => nullableUniqueItem.id.equalsValue(id),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<NullableUniqueItem, NullableUniqueItemCursor>? request =
+  ///     NullableUniqueItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [NullableUniqueItemCursor].
+  Future<Page<NullableUniqueItem, NullableUniqueItemCursor>> fetchPage(
+    PageRequest<NullableUniqueItem, NullableUniqueItemCursor> request,
+  ) =>
+      $ForGeneratedCode.fetchPage<NullableUniqueItem, NullableUniqueItemCursor>(
+        query: this,
+        request: request,
+      );
 
   /// Update all rows in the `nullableUniqueItems` table matching this [Query].
   ///
@@ -1904,6 +2196,73 @@ extension TableSubQueryItemExt on Table<SubQueryItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$SubQueryItem._$table);
 }
 
+/// Pagination cursor referencing a row in [SubQueryItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SubQueryItemCursor {
+  const SubQueryItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'SubQueryItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [SubQueryItem], used by
+/// `.fetchPage(...)`.
+final class SubQueryItemDirection {
+  const SubQueryItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SubQueryItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SubQueryItemPageRequest
+    implements PageRequest<SubQueryItem, SubQueryItemCursor> {
+  const SubQueryItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SubQueryItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SubQueryItemCursor? cursor;
+
+  final SubQueryItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SubQueryItem> subQueryItem) => [
+    (subQueryItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SubQueryItem> subQueryItem) =>
+      direction.id == Order.ascending
+      ? subQueryItem.id > toExpr(cursor!.id)
+      : subQueryItem.id < toExpr(cursor!.id);
+
+  @override
+  SubQueryItemCursor cursorOf(SubQueryItem subQueryItem) =>
+      SubQueryItemCursor(id: subQueryItem.id);
+
+  @override
+  SubQueryItemPageRequest withCursor(SubQueryItemCursor cursor) =>
+      SubQueryItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `subQueryItems` table.
 extension QuerySubQueryItemExt on Query<(Expr<SubQueryItem>,)> {
   /// Lookup a single row in `subQueryItems` table using the _primary key_.
@@ -1912,6 +2271,30 @@ extension QuerySubQueryItemExt on Query<(Expr<SubQueryItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<SubQueryItem>,)> byKey(int id) =>
       where((subQueryItem) => subQueryItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SubQueryItem, SubQueryItemCursor>? request =
+  ///     SubQueryItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SubQueryItemCursor].
+  Future<Page<SubQueryItem, SubQueryItemCursor>> fetchPage(
+    PageRequest<SubQueryItem, SubQueryItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SubQueryItem, SubQueryItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `subQueryItems` table matching this [Query].
   ///
@@ -2521,6 +2904,87 @@ extension TableComplexItemExt on Table<ComplexItem> {
       );
 }
 
+/// Pagination cursor referencing a row in [ComplexItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ComplexItemCursor {
+  const ComplexItemCursor({required this.id, required this.createdAt});
+
+  final int id;
+
+  final DateTime createdAt;
+
+  @override
+  String toString() => 'ComplexItemCursor(id: "$id", createdAt: "$createdAt")';
+}
+
+/// Sort direction for each _primary key_ field of [ComplexItem], used by
+/// `.fetchPage(...)`.
+final class ComplexItemDirection {
+  const ComplexItemDirection({
+    this.id = Order.ascending,
+    this.createdAt = Order.ascending,
+  });
+
+  final Order id;
+
+  final Order createdAt;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ComplexItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ComplexItemPageRequest
+    implements PageRequest<ComplexItem, ComplexItemCursor> {
+  const ComplexItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ComplexItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ComplexItemCursor? cursor;
+
+  final ComplexItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<ComplexItem> complexItem) => [
+    (complexItem.id, direction.id),
+    (complexItem.createdAt, direction.createdAt),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<ComplexItem> complexItem) =>
+      (direction.id == Order.ascending
+              ? complexItem.id > toExpr(cursor!.id)
+              : complexItem.id < toExpr(cursor!.id))
+          .or(
+            complexItem.id.equalsValue(cursor!.id) &
+                (direction.createdAt == Order.ascending
+                    ? complexItem.createdAt > toExpr(cursor!.createdAt)
+                    : complexItem.createdAt < toExpr(cursor!.createdAt)),
+          );
+
+  @override
+  ComplexItemCursor cursorOf(ComplexItem complexItem) =>
+      ComplexItemCursor(id: complexItem.id, createdAt: complexItem.createdAt);
+
+  @override
+  ComplexItemPageRequest withCursor(ComplexItemCursor cursor) =>
+      ComplexItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `complexItems` table.
 extension QueryComplexItemExt on Query<(Expr<ComplexItem>,)> {
   /// Lookup a single row in `complexItems` table using the _primary key_.
@@ -2532,6 +2996,30 @@ extension QueryComplexItemExt on Query<(Expr<ComplexItem>,)> {
         complexItem.id.equalsValue(id) &
         complexItem.createdAt.equalsValue(createdAt),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ComplexItem, ComplexItemCursor>? request =
+  ///     ComplexItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ComplexItemCursor].
+  Future<Page<ComplexItem, ComplexItemCursor>> fetchPage(
+    PageRequest<ComplexItem, ComplexItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<ComplexItem, ComplexItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `complexItems` table matching this [Query].
   ///
@@ -3100,6 +3588,73 @@ extension TableCustomTypeItemExt on Table<CustomTypeItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$CustomTypeItem._$table);
 }
 
+/// Pagination cursor referencing a row in [CustomTypeItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CustomTypeItemCursor {
+  const CustomTypeItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'CustomTypeItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [CustomTypeItem], used by
+/// `.fetchPage(...)`.
+final class CustomTypeItemDirection {
+  const CustomTypeItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [CustomTypeItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CustomTypeItemPageRequest
+    implements PageRequest<CustomTypeItem, CustomTypeItemCursor> {
+  const CustomTypeItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CustomTypeItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CustomTypeItemCursor? cursor;
+
+  final CustomTypeItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<CustomTypeItem> customTypeItem,
+  ) => [(customTypeItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<CustomTypeItem> customTypeItem) =>
+      direction.id == Order.ascending
+      ? customTypeItem.id > toExpr(cursor!.id)
+      : customTypeItem.id < toExpr(cursor!.id);
+
+  @override
+  CustomTypeItemCursor cursorOf(CustomTypeItem customTypeItem) =>
+      CustomTypeItemCursor(id: customTypeItem.id);
+
+  @override
+  CustomTypeItemPageRequest withCursor(CustomTypeItemCursor cursor) =>
+      CustomTypeItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `customTypeItems` table.
 extension QueryCustomTypeItemExt on Query<(Expr<CustomTypeItem>,)> {
   /// Lookup a single row in `customTypeItems` table using the _primary key_.
@@ -3108,6 +3663,30 @@ extension QueryCustomTypeItemExt on Query<(Expr<CustomTypeItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<CustomTypeItem>,)> byKey(int id) =>
       where((customTypeItem) => customTypeItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<CustomTypeItem, CustomTypeItemCursor>? request =
+  ///     CustomTypeItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CustomTypeItemCursor].
+  Future<Page<CustomTypeItem, CustomTypeItemCursor>> fetchPage(
+    PageRequest<CustomTypeItem, CustomTypeItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<CustomTypeItem, CustomTypeItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `customTypeItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_basic/upsert_basic_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_basic/upsert_basic_test.g.dart
@@ -177,6 +177,73 @@ extension TableBasicItemExt on Table<BasicItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$BasicItem._$table);
 }
 
+/// Pagination cursor referencing a row in [BasicItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BasicItemCursor {
+  const BasicItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'BasicItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [BasicItem], used by
+/// `.fetchPage(...)`.
+final class BasicItemDirection {
+  const BasicItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [BasicItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BasicItemPageRequest
+    implements PageRequest<BasicItem, BasicItemCursor> {
+  const BasicItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BasicItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BasicItemCursor? cursor;
+
+  final BasicItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<BasicItem> basicItem) => [
+    (basicItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<BasicItem> basicItem) =>
+      direction.id == Order.ascending
+      ? basicItem.id > toExpr(cursor!.id)
+      : basicItem.id < toExpr(cursor!.id);
+
+  @override
+  BasicItemCursor cursorOf(BasicItem basicItem) =>
+      BasicItemCursor(id: basicItem.id);
+
+  @override
+  BasicItemPageRequest withCursor(BasicItemCursor cursor) =>
+      BasicItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `basicItems` table.
 extension QueryBasicItemExt on Query<(Expr<BasicItem>,)> {
   /// Lookup a single row in `basicItems` table using the _primary key_.
@@ -185,6 +252,30 @@ extension QueryBasicItemExt on Query<(Expr<BasicItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<BasicItem>,)> byKey(int id) =>
       where((basicItem) => basicItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<BasicItem, BasicItemCursor>? request =
+  ///     BasicItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BasicItemCursor].
+  Future<Page<BasicItem, BasicItemCursor>> fetchPage(
+    PageRequest<BasicItem, BasicItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<BasicItem, BasicItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `basicItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_complex/upsert_complex_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_complex/upsert_complex_test.g.dart
@@ -262,6 +262,87 @@ extension TableComplexItemExt on Table<ComplexItem> {
       );
 }
 
+/// Pagination cursor referencing a row in [ComplexItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ComplexItemCursor {
+  const ComplexItemCursor({required this.id, required this.createdAt});
+
+  final int id;
+
+  final DateTime createdAt;
+
+  @override
+  String toString() => 'ComplexItemCursor(id: "$id", createdAt: "$createdAt")';
+}
+
+/// Sort direction for each _primary key_ field of [ComplexItem], used by
+/// `.fetchPage(...)`.
+final class ComplexItemDirection {
+  const ComplexItemDirection({
+    this.id = Order.ascending,
+    this.createdAt = Order.ascending,
+  });
+
+  final Order id;
+
+  final Order createdAt;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [ComplexItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ComplexItemPageRequest
+    implements PageRequest<ComplexItem, ComplexItemCursor> {
+  const ComplexItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ComplexItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ComplexItemCursor? cursor;
+
+  final ComplexItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<ComplexItem> complexItem) => [
+    (complexItem.id, direction.id),
+    (complexItem.createdAt, direction.createdAt),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<ComplexItem> complexItem) =>
+      (direction.id == Order.ascending
+              ? complexItem.id > toExpr(cursor!.id)
+              : complexItem.id < toExpr(cursor!.id))
+          .or(
+            complexItem.id.equalsValue(cursor!.id) &
+                (direction.createdAt == Order.ascending
+                    ? complexItem.createdAt > toExpr(cursor!.createdAt)
+                    : complexItem.createdAt < toExpr(cursor!.createdAt)),
+          );
+
+  @override
+  ComplexItemCursor cursorOf(ComplexItem complexItem) =>
+      ComplexItemCursor(id: complexItem.id, createdAt: complexItem.createdAt);
+
+  @override
+  ComplexItemPageRequest withCursor(ComplexItemCursor cursor) =>
+      ComplexItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `complexItems` table.
 extension QueryComplexItemExt on Query<(Expr<ComplexItem>,)> {
   /// Lookup a single row in `complexItems` table using the _primary key_.
@@ -273,6 +354,30 @@ extension QueryComplexItemExt on Query<(Expr<ComplexItem>,)> {
         complexItem.id.equalsValue(id) &
         complexItem.createdAt.equalsValue(createdAt),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<ComplexItem, ComplexItemCursor>? request =
+  ///     ComplexItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ComplexItemCursor].
+  Future<Page<ComplexItem, ComplexItemCursor>> fetchPage(
+    PageRequest<ComplexItem, ComplexItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<ComplexItem, ComplexItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `complexItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_customtype/upsert_customtype_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_customtype/upsert_customtype_test.g.dart
@@ -162,6 +162,73 @@ extension TableCustomTypeItemExt on Table<CustomTypeItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$CustomTypeItem._$table);
 }
 
+/// Pagination cursor referencing a row in [CustomTypeItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class CustomTypeItemCursor {
+  const CustomTypeItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'CustomTypeItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [CustomTypeItem], used by
+/// `.fetchPage(...)`.
+final class CustomTypeItemDirection {
+  const CustomTypeItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [CustomTypeItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class CustomTypeItemPageRequest
+    implements PageRequest<CustomTypeItem, CustomTypeItemCursor> {
+  const CustomTypeItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const CustomTypeItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final CustomTypeItemCursor? cursor;
+
+  final CustomTypeItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<CustomTypeItem> customTypeItem,
+  ) => [(customTypeItem.id, direction.id)];
+
+  @override
+  Expr<bool?> where(Expr<CustomTypeItem> customTypeItem) =>
+      direction.id == Order.ascending
+      ? customTypeItem.id > toExpr(cursor!.id)
+      : customTypeItem.id < toExpr(cursor!.id);
+
+  @override
+  CustomTypeItemCursor cursorOf(CustomTypeItem customTypeItem) =>
+      CustomTypeItemCursor(id: customTypeItem.id);
+
+  @override
+  CustomTypeItemPageRequest withCursor(CustomTypeItemCursor cursor) =>
+      CustomTypeItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `customTypeItems` table.
 extension QueryCustomTypeItemExt on Query<(Expr<CustomTypeItem>,)> {
   /// Lookup a single row in `customTypeItems` table using the _primary key_.
@@ -170,6 +237,30 @@ extension QueryCustomTypeItemExt on Query<(Expr<CustomTypeItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<CustomTypeItem>,)> byKey(int id) =>
       where((customTypeItem) => customTypeItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<CustomTypeItem, CustomTypeItemCursor>? request =
+  ///     CustomTypeItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [CustomTypeItemCursor].
+  Future<Page<CustomTypeItem, CustomTypeItemCursor>> fetchPage(
+    PageRequest<CustomTypeItem, CustomTypeItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<CustomTypeItem, CustomTypeItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `customTypeItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_multi_conflict/upsert_multi_conflict_test.g.dart
@@ -206,6 +206,73 @@ extension TableMultiItemExt on Table<MultiItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$MultiItem._$table);
 }
 
+/// Pagination cursor referencing a row in [MultiItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class MultiItemCursor {
+  const MultiItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'MultiItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [MultiItem], used by
+/// `.fetchPage(...)`.
+final class MultiItemDirection {
+  const MultiItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [MultiItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class MultiItemPageRequest
+    implements PageRequest<MultiItem, MultiItemCursor> {
+  const MultiItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const MultiItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final MultiItemCursor? cursor;
+
+  final MultiItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<MultiItem> multiItem) => [
+    (multiItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<MultiItem> multiItem) =>
+      direction.id == Order.ascending
+      ? multiItem.id > toExpr(cursor!.id)
+      : multiItem.id < toExpr(cursor!.id);
+
+  @override
+  MultiItemCursor cursorOf(MultiItem multiItem) =>
+      MultiItemCursor(id: multiItem.id);
+
+  @override
+  MultiItemPageRequest withCursor(MultiItemCursor cursor) =>
+      MultiItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `multiItems` table.
 extension QueryMultiItemExt on Query<(Expr<MultiItem>,)> {
   /// Lookup a single row in `multiItems` table using the _primary key_.
@@ -214,6 +281,30 @@ extension QueryMultiItemExt on Query<(Expr<MultiItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<MultiItem>,)> byKey(int id) =>
       where((multiItem) => multiItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<MultiItem, MultiItemCursor>? request =
+  ///     MultiItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [MultiItemCursor].
+  Future<Page<MultiItem, MultiItemCursor>> fetchPage(
+    PageRequest<MultiItem, MultiItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<MultiItem, MultiItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `multiItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_negative/upsert_negative_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_negative/upsert_negative_test.g.dart
@@ -155,6 +155,73 @@ extension TableNotNullItemExt on Table<NotNullItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$NotNullItem._$table);
 }
 
+/// Pagination cursor referencing a row in [NotNullItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class NotNullItemCursor {
+  const NotNullItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'NotNullItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [NotNullItem], used by
+/// `.fetchPage(...)`.
+final class NotNullItemDirection {
+  const NotNullItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [NotNullItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class NotNullItemPageRequest
+    implements PageRequest<NotNullItem, NotNullItemCursor> {
+  const NotNullItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const NotNullItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final NotNullItemCursor? cursor;
+
+  final NotNullItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<NotNullItem> notNullItem) => [
+    (notNullItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<NotNullItem> notNullItem) =>
+      direction.id == Order.ascending
+      ? notNullItem.id > toExpr(cursor!.id)
+      : notNullItem.id < toExpr(cursor!.id);
+
+  @override
+  NotNullItemCursor cursorOf(NotNullItem notNullItem) =>
+      NotNullItemCursor(id: notNullItem.id);
+
+  @override
+  NotNullItemPageRequest withCursor(NotNullItemCursor cursor) =>
+      NotNullItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `notNullItems` table.
 extension QueryNotNullItemExt on Query<(Expr<NotNullItem>,)> {
   /// Lookup a single row in `notNullItems` table using the _primary key_.
@@ -163,6 +230,30 @@ extension QueryNotNullItemExt on Query<(Expr<NotNullItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<NotNullItem>,)> byKey(int id) =>
       where((notNullItem) => notNullItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<NotNullItem, NotNullItemCursor>? request =
+  ///     NotNullItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [NotNullItemCursor].
+  Future<Page<NotNullItem, NotNullItemCursor>> fetchPage(
+    PageRequest<NotNullItem, NotNullItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<NotNullItem, NotNullItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `notNullItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/insert/upsert_subquery/upsert_subquery_test.g.dart
+++ b/typed_sql/test/typed_sql/insert/upsert_subquery/upsert_subquery_test.g.dart
@@ -158,6 +158,73 @@ extension TableSourceItemExt on Table<SourceItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$SourceItem._$table);
 }
 
+/// Pagination cursor referencing a row in [SourceItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SourceItemCursor {
+  const SourceItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'SourceItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [SourceItem], used by
+/// `.fetchPage(...)`.
+final class SourceItemDirection {
+  const SourceItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SourceItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SourceItemPageRequest
+    implements PageRequest<SourceItem, SourceItemCursor> {
+  const SourceItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SourceItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SourceItemCursor? cursor;
+
+  final SourceItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SourceItem> sourceItem) => [
+    (sourceItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SourceItem> sourceItem) =>
+      direction.id == Order.ascending
+      ? sourceItem.id > toExpr(cursor!.id)
+      : sourceItem.id < toExpr(cursor!.id);
+
+  @override
+  SourceItemCursor cursorOf(SourceItem sourceItem) =>
+      SourceItemCursor(id: sourceItem.id);
+
+  @override
+  SourceItemPageRequest withCursor(SourceItemCursor cursor) =>
+      SourceItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `sourceItems` table.
 extension QuerySourceItemExt on Query<(Expr<SourceItem>,)> {
   /// Lookup a single row in `sourceItems` table using the _primary key_.
@@ -166,6 +233,30 @@ extension QuerySourceItemExt on Query<(Expr<SourceItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<SourceItem>,)> byKey(int id) =>
       where((sourceItem) => sourceItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SourceItem, SourceItemCursor>? request =
+  ///     SourceItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SourceItemCursor].
+  Future<Page<SourceItem, SourceItemCursor>> fetchPage(
+    PageRequest<SourceItem, SourceItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SourceItem, SourceItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `sourceItems` table matching this [Query].
   ///
@@ -644,6 +735,73 @@ extension TableSubQueryItemExt on Table<SubQueryItem> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$SubQueryItem._$table);
 }
 
+/// Pagination cursor referencing a row in [SubQueryItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SubQueryItemCursor {
+  const SubQueryItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'SubQueryItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [SubQueryItem], used by
+/// `.fetchPage(...)`.
+final class SubQueryItemDirection {
+  const SubQueryItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SubQueryItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SubQueryItemPageRequest
+    implements PageRequest<SubQueryItem, SubQueryItemCursor> {
+  const SubQueryItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SubQueryItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SubQueryItemCursor? cursor;
+
+  final SubQueryItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SubQueryItem> subQueryItem) => [
+    (subQueryItem.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SubQueryItem> subQueryItem) =>
+      direction.id == Order.ascending
+      ? subQueryItem.id > toExpr(cursor!.id)
+      : subQueryItem.id < toExpr(cursor!.id);
+
+  @override
+  SubQueryItemCursor cursorOf(SubQueryItem subQueryItem) =>
+      SubQueryItemCursor(id: subQueryItem.id);
+
+  @override
+  SubQueryItemPageRequest withCursor(SubQueryItemCursor cursor) =>
+      SubQueryItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `subQueryItems` table.
 extension QuerySubQueryItemExt on Query<(Expr<SubQueryItem>,)> {
   /// Lookup a single row in `subQueryItems` table using the _primary key_.
@@ -652,6 +810,30 @@ extension QuerySubQueryItemExt on Query<(Expr<SubQueryItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<SubQueryItem>,)> byKey(int id) =>
       where((subQueryItem) => subQueryItem.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SubQueryItem, SubQueryItemCursor>? request =
+  ///     SubQueryItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SubQueryItemCursor].
+  Future<Page<SubQueryItem, SubQueryItemCursor>> fetchPage(
+    PageRequest<SubQueryItem, SubQueryItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SubQueryItem, SubQueryItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `subQueryItems` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_model/join_model_test.g.dart
@@ -178,6 +178,72 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.employeeId});
+
+  final int employeeId;
+
+  @override
+  String toString() => 'EmployeeCursor(employeeId: "$employeeId")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.employeeId = Order.ascending});
+
+  final Order employeeId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.employeeId, direction.employeeId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) =>
+      direction.employeeId == Order.ascending
+      ? employee.employeeId > toExpr(cursor!.employeeId)
+      : employee.employeeId < toExpr(cursor!.employeeId);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) =>
+      EmployeeCursor(employeeId: employee.employeeId);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -186,6 +252,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
       where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///
@@ -674,6 +764,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.departmentId});
+
+  final int departmentId;
+
+  @override
+  String toString() => 'DepartmentCursor(departmentId: "$departmentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.departmentId = Order.ascending});
+
+  final Order departmentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.departmentId, direction.departmentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.departmentId == Order.ascending
+      ? department.departmentId > toExpr(cursor!.departmentId)
+      : department.departmentId < toExpr(cursor!.departmentId);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(departmentId: department.departmentId);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -683,6 +840,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
     (department) => department.departmentId.equalsValue(departmentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_query/join_query_test.g.dart
@@ -178,6 +178,72 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.employeeId});
+
+  final int employeeId;
+
+  @override
+  String toString() => 'EmployeeCursor(employeeId: "$employeeId")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.employeeId = Order.ascending});
+
+  final Order employeeId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.employeeId, direction.employeeId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) =>
+      direction.employeeId == Order.ascending
+      ? employee.employeeId > toExpr(cursor!.employeeId)
+      : employee.employeeId < toExpr(cursor!.employeeId);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) =>
+      EmployeeCursor(employeeId: employee.employeeId);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -186,6 +252,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
       where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///
@@ -674,6 +764,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.departmentId});
+
+  final int departmentId;
+
+  @override
+  String toString() => 'DepartmentCursor(departmentId: "$departmentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.departmentId = Order.ascending});
+
+  final Order departmentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.departmentId, direction.departmentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.departmentId == Order.ascending
+      ? department.departmentId > toExpr(cursor!.departmentId)
+      : department.departmentId < toExpr(cursor!.departmentId);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(departmentId: department.departmentId);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -683,6 +840,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
     (department) => department.departmentId.equalsValue(departmentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
+++ b/typed_sql/test/typed_sql/join/join_using/join_using_test.g.dart
@@ -187,6 +187,72 @@ extension TableEmployeeExt on Table<Employee> {
       $ForGeneratedCode.deleteSingle(byKey(employeeId), _$Employee._$table);
 }
 
+/// Pagination cursor referencing a row in [Employee].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class EmployeeCursor {
+  const EmployeeCursor({required this.employeeId});
+
+  final int employeeId;
+
+  @override
+  String toString() => 'EmployeeCursor(employeeId: "$employeeId")';
+}
+
+/// Sort direction for each _primary key_ field of [Employee], used by
+/// `.fetchPage(...)`.
+final class EmployeeDirection {
+  const EmployeeDirection({this.employeeId = Order.ascending});
+
+  final Order employeeId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Employee].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class EmployeePageRequest
+    implements PageRequest<Employee, EmployeeCursor> {
+  const EmployeePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const EmployeeDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final EmployeeCursor? cursor;
+
+  final EmployeeDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Employee> employee) => [
+    (employee.employeeId, direction.employeeId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Employee> employee) =>
+      direction.employeeId == Order.ascending
+      ? employee.employeeId > toExpr(cursor!.employeeId)
+      : employee.employeeId < toExpr(cursor!.employeeId);
+
+  @override
+  EmployeeCursor cursorOf(Employee employee) =>
+      EmployeeCursor(employeeId: employee.employeeId);
+
+  @override
+  EmployeePageRequest withCursor(EmployeeCursor cursor) => EmployeePageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `employees` table.
 extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// Lookup a single row in `employees` table using the _primary key_.
@@ -195,6 +261,30 @@ extension QueryEmployeeExt on Query<(Expr<Employee>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Employee>,)> byKey(int employeeId) =>
       where((employee) => employee.employeeId.equalsValue(employeeId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Employee, EmployeeCursor>? request =
+  ///     EmployeePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [EmployeeCursor].
+  Future<Page<Employee, EmployeeCursor>> fetchPage(
+    PageRequest<Employee, EmployeeCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Employee, EmployeeCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `employees` table matching this [Query].
   ///
@@ -736,6 +826,73 @@ extension TableDepartmentExt on Table<Department> {
       $ForGeneratedCode.deleteSingle(byKey(departmentId), _$Department._$table);
 }
 
+/// Pagination cursor referencing a row in [Department].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DepartmentCursor {
+  const DepartmentCursor({required this.departmentId});
+
+  final int departmentId;
+
+  @override
+  String toString() => 'DepartmentCursor(departmentId: "$departmentId")';
+}
+
+/// Sort direction for each _primary key_ field of [Department], used by
+/// `.fetchPage(...)`.
+final class DepartmentDirection {
+  const DepartmentDirection({this.departmentId = Order.ascending});
+
+  final Order departmentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Department].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DepartmentPageRequest
+    implements PageRequest<Department, DepartmentCursor> {
+  const DepartmentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DepartmentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DepartmentCursor? cursor;
+
+  final DepartmentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Department> department) => [
+    (department.departmentId, direction.departmentId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Department> department) =>
+      direction.departmentId == Order.ascending
+      ? department.departmentId > toExpr(cursor!.departmentId)
+      : department.departmentId < toExpr(cursor!.departmentId);
+
+  @override
+  DepartmentCursor cursorOf(Department department) =>
+      DepartmentCursor(departmentId: department.departmentId);
+
+  @override
+  DepartmentPageRequest withCursor(DepartmentCursor cursor) =>
+      DepartmentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `departments` table.
 extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   /// Lookup a single row in `departments` table using the _primary key_.
@@ -745,6 +902,30 @@ extension QueryDepartmentExt on Query<(Expr<Department>,)> {
   QuerySingle<(Expr<Department>,)> byKey(int departmentId) => where(
     (department) => department.departmentId.equalsValue(departmentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Department, DepartmentCursor>? request =
+  ///     DepartmentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DepartmentCursor].
+  Future<Page<Department, DepartmentCursor>> fetchPage(
+    PageRequest<Department, DepartmentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Department, DepartmentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `departments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/join/nullable_on/nullable_on_test.g.dart
+++ b/typed_sql/test/typed_sql/join/nullable_on/nullable_on_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.g.dart
+++ b/typed_sql/test/typed_sql/json/deep_extraction/deep_extraction_test.g.dart
@@ -169,6 +169,69 @@ extension TableProductExt on Table<Product> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
 }
 
+/// Pagination cursor referencing a row in [Product].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ProductCursor {
+  const ProductCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ProductCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Product], used by
+/// `.fetchPage(...)`.
+final class ProductDirection {
+  const ProductDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Product].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ProductPageRequest implements PageRequest<Product, ProductCursor> {
+  const ProductPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ProductDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ProductCursor? cursor;
+
+  final ProductDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Product> product) => [
+    (product.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Product> product) => direction.id == Order.ascending
+      ? product.id > toExpr(cursor!.id)
+      : product.id < toExpr(cursor!.id);
+
+  @override
+  ProductCursor cursorOf(Product product) => ProductCursor(id: product.id);
+
+  @override
+  ProductPageRequest withCursor(ProductCursor cursor) => ProductPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `products` table.
 extension QueryProductExt on Query<(Expr<Product>,)> {
   /// Lookup a single row in `products` table using the _primary key_.
@@ -177,6 +240,30 @@ extension QueryProductExt on Query<(Expr<Product>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Product>,)> byKey(int id) =>
       where((product) => product.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Product, ProductCursor>? request =
+  ///     ProductPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ProductCursor].
+  Future<Page<Product, ProductCursor>> fetchPage(
+    PageRequest<Product, ProductCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Product, ProductCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `products` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/json/null_handling/null_handling_test.g.dart
+++ b/typed_sql/test/typed_sql/json/null_handling/null_handling_test.g.dart
@@ -169,6 +169,69 @@ extension TableProductExt on Table<Product> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Product._$table);
 }
 
+/// Pagination cursor referencing a row in [Product].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ProductCursor {
+  const ProductCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ProductCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Product], used by
+/// `.fetchPage(...)`.
+final class ProductDirection {
+  const ProductDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Product].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ProductPageRequest implements PageRequest<Product, ProductCursor> {
+  const ProductPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ProductDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ProductCursor? cursor;
+
+  final ProductDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Product> product) => [
+    (product.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Product> product) => direction.id == Order.ascending
+      ? product.id > toExpr(cursor!.id)
+      : product.id < toExpr(cursor!.id);
+
+  @override
+  ProductCursor cursorOf(Product product) => ProductCursor(id: product.id);
+
+  @override
+  ProductPageRequest withCursor(ProductCursor cursor) => ProductPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `products` table.
 extension QueryProductExt on Query<(Expr<Product>,)> {
   /// Lookup a single row in `products` table using the _primary key_.
@@ -177,6 +240,30 @@ extension QueryProductExt on Query<(Expr<Product>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Product>,)> byKey(int id) =>
       where((product) => product.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Product, ProductCursor>? request =
+  ///     ProductPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ProductCursor].
+  Future<Page<Product, ProductCursor>> fetchPage(
+    PageRequest<Product, ProductCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Product, ProductCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `products` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
+++ b/typed_sql/test/typed_sql/key/autoincrement/autoincrement_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/composite_key/composite_key_test.g.dart
@@ -174,6 +174,78 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id, name), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id, required this.name});
+
+  final int id;
+
+  final String name;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id", name: "$name")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending, this.name = Order.ascending});
+
+  final Order id;
+
+  final Order name;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+    (item.name, direction.name),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) =>
+      (direction.id == Order.ascending
+              ? item.id > toExpr(cursor!.id)
+              : item.id < toExpr(cursor!.id))
+          .or(
+            item.id.equalsValue(cursor!.id) &
+                (direction.name == Order.ascending
+                    ? item.name > toExpr(cursor!.name)
+                    : item.name < toExpr(cursor!.name)),
+          );
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id, name: item.name);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -183,6 +255,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   QuerySingle<(Expr<Item>,)> byKey(int id, String name) => where(
     (item) => item.id.equalsValue(id) & item.name.equalsValue(name),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
+++ b/typed_sql/test/typed_sql/key/text_key/text_key_test.g.dart
@@ -160,6 +160,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(key), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.key});
+
+  final String key;
+
+  @override
+  String toString() => 'ItemCursor(key: "$key")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.key = Order.ascending});
+
+  final Order key;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.key, direction.key),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.key == Order.ascending
+      ? item.key > toExpr(cursor!.key)
+      : item.key < toExpr(cursor!.key);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(key: item.key);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -168,6 +228,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(String key) =>
       where((item) => item.key.equalsValue(key)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/blob/blob_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/blob/blob_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_boolean/nullable_boolean_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_datetime/nullable_datetime_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_integer/nullable_integer_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_json/nullable_json_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_real/nullable_real_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
+++ b/typed_sql/test/typed_sql/nullable/nullable_text/nullable_text_test.g.dart
@@ -146,6 +146,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -154,6 +214,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
+++ b/typed_sql/test/typed_sql/order_by/order_by_composite/order_by_composite_test.g.dart
@@ -209,6 +209,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -217,6 +277,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/overrides/dialect_specific_ddl/dialect_specific_ddl_test.g.dart
+++ b/typed_sql/test/typed_sql/overrides/dialect_specific_ddl/dialect_specific_ddl_test.g.dart
@@ -273,6 +273,73 @@ extension TableDialectItemExt on Table<DialectItem> {
       $ForGeneratedCode.deleteSingle(byKey(itemId), _$DialectItem._$table);
 }
 
+/// Pagination cursor referencing a row in [DialectItem].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DialectItemCursor {
+  const DialectItemCursor({required this.itemId});
+
+  final int itemId;
+
+  @override
+  String toString() => 'DialectItemCursor(itemId: "$itemId")';
+}
+
+/// Sort direction for each _primary key_ field of [DialectItem], used by
+/// `.fetchPage(...)`.
+final class DialectItemDirection {
+  const DialectItemDirection({this.itemId = Order.ascending});
+
+  final Order itemId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [DialectItem].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DialectItemPageRequest
+    implements PageRequest<DialectItem, DialectItemCursor> {
+  const DialectItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DialectItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DialectItemCursor? cursor;
+
+  final DialectItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<DialectItem> dialectItem) => [
+    (dialectItem.itemId, direction.itemId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<DialectItem> dialectItem) =>
+      direction.itemId == Order.ascending
+      ? dialectItem.itemId > toExpr(cursor!.itemId)
+      : dialectItem.itemId < toExpr(cursor!.itemId);
+
+  @override
+  DialectItemCursor cursorOf(DialectItem dialectItem) =>
+      DialectItemCursor(itemId: dialectItem.itemId);
+
+  @override
+  DialectItemPageRequest withCursor(DialectItemCursor cursor) =>
+      DialectItemPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `dialectItems` table.
 extension QueryDialectItemExt on Query<(Expr<DialectItem>,)> {
   /// Lookup a single row in `dialectItems` table using the _primary key_.
@@ -281,6 +348,30 @@ extension QueryDialectItemExt on Query<(Expr<DialectItem>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<DialectItem>,)> byKey(int itemId) =>
       where((dialectItem) => dialectItem.itemId.equalsValue(itemId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<DialectItem, DialectItemCursor>? request =
+  ///     DialectItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DialectItemCursor].
+  Future<Page<DialectItem, DialectItemCursor>> fetchPage(
+    PageRequest<DialectItem, DialectItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<DialectItem, DialectItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `dialectItems` table matching this [Query].
   ///
@@ -833,6 +924,73 @@ extension TableDialectLogExt on Table<DialectLog> {
       $ForGeneratedCode.deleteSingle(byKey(logId), _$DialectLog._$table);
 }
 
+/// Pagination cursor referencing a row in [DialectLog].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class DialectLogCursor {
+  const DialectLogCursor({required this.logId});
+
+  final int logId;
+
+  @override
+  String toString() => 'DialectLogCursor(logId: "$logId")';
+}
+
+/// Sort direction for each _primary key_ field of [DialectLog], used by
+/// `.fetchPage(...)`.
+final class DialectLogDirection {
+  const DialectLogDirection({this.logId = Order.ascending});
+
+  final Order logId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [DialectLog].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class DialectLogPageRequest
+    implements PageRequest<DialectLog, DialectLogCursor> {
+  const DialectLogPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const DialectLogDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final DialectLogCursor? cursor;
+
+  final DialectLogDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<DialectLog> dialectLog) => [
+    (dialectLog.logId, direction.logId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<DialectLog> dialectLog) =>
+      direction.logId == Order.ascending
+      ? dialectLog.logId > toExpr(cursor!.logId)
+      : dialectLog.logId < toExpr(cursor!.logId);
+
+  @override
+  DialectLogCursor cursorOf(DialectLog dialectLog) =>
+      DialectLogCursor(logId: dialectLog.logId);
+
+  @override
+  DialectLogPageRequest withCursor(DialectLogCursor cursor) =>
+      DialectLogPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `dialectLogs` table.
 extension QueryDialectLogExt on Query<(Expr<DialectLog>,)> {
   /// Lookup a single row in `dialectLogs` table using the _primary key_.
@@ -841,6 +999,30 @@ extension QueryDialectLogExt on Query<(Expr<DialectLog>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<DialectLog>,)> byKey(int logId) =>
       where((dialectLog) => dialectLog.logId.equalsValue(logId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<DialectLog, DialectLogCursor>? request =
+  ///     DialectLogPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [DialectLogCursor].
+  Future<Page<DialectLog, DialectLogCursor>> fetchPage(
+    PageRequest<DialectLog, DialectLogCursor> request,
+  ) => $ForGeneratedCode.fetchPage<DialectLog, DialectLogCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `dialectLogs` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/overrides/hierarchical_naming/hierarchical_naming_test.g.dart
+++ b/typed_sql/test/typed_sql/overrides/hierarchical_naming/hierarchical_naming_test.g.dart
@@ -267,6 +267,72 @@ extension TableHierarchyUserExt on Table<HierarchyUser> {
       $ForGeneratedCode.deleteSingle(byKey(userId), _$HierarchyUser._$table);
 }
 
+/// Pagination cursor referencing a row in [HierarchyUser].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class HierarchyUserCursor {
+  const HierarchyUserCursor({required this.userId});
+
+  final int userId;
+
+  @override
+  String toString() => 'HierarchyUserCursor(userId: "$userId")';
+}
+
+/// Sort direction for each _primary key_ field of [HierarchyUser], used by
+/// `.fetchPage(...)`.
+final class HierarchyUserDirection {
+  const HierarchyUserDirection({this.userId = Order.ascending});
+
+  final Order userId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [HierarchyUser].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class HierarchyUserPageRequest
+    implements PageRequest<HierarchyUser, HierarchyUserCursor> {
+  const HierarchyUserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const HierarchyUserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final HierarchyUserCursor? cursor;
+
+  final HierarchyUserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<HierarchyUser> hierarchyUser) =>
+      [(hierarchyUser.userId, direction.userId)];
+
+  @override
+  Expr<bool?> where(Expr<HierarchyUser> hierarchyUser) =>
+      direction.userId == Order.ascending
+      ? hierarchyUser.userId > toExpr(cursor!.userId)
+      : hierarchyUser.userId < toExpr(cursor!.userId);
+
+  @override
+  HierarchyUserCursor cursorOf(HierarchyUser hierarchyUser) =>
+      HierarchyUserCursor(userId: hierarchyUser.userId);
+
+  @override
+  HierarchyUserPageRequest withCursor(HierarchyUserCursor cursor) =>
+      HierarchyUserPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `hierarchyUsers` table.
 extension QueryHierarchyUserExt on Query<(Expr<HierarchyUser>,)> {
   /// Lookup a single row in `hierarchyUsers` table using the _primary key_.
@@ -275,6 +341,30 @@ extension QueryHierarchyUserExt on Query<(Expr<HierarchyUser>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<HierarchyUser>,)> byKey(int userId) =>
       where((hierarchyUser) => hierarchyUser.userId.equalsValue(userId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<HierarchyUser, HierarchyUserCursor>? request =
+  ///     HierarchyUserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [HierarchyUserCursor].
+  Future<Page<HierarchyUser, HierarchyUserCursor>> fetchPage(
+    PageRequest<HierarchyUser, HierarchyUserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<HierarchyUser, HierarchyUserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `hierarchyUsers` table matching this [Query].
   ///
@@ -859,6 +949,73 @@ extension TableHierarchyProfileExt on Table<HierarchyProfile> {
       .deleteSingle(byKey(profileId), _$HierarchyProfile._$table);
 }
 
+/// Pagination cursor referencing a row in [HierarchyProfile].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class HierarchyProfileCursor {
+  const HierarchyProfileCursor({required this.profileId});
+
+  final int profileId;
+
+  @override
+  String toString() => 'HierarchyProfileCursor(profileId: "$profileId")';
+}
+
+/// Sort direction for each _primary key_ field of [HierarchyProfile], used by
+/// `.fetchPage(...)`.
+final class HierarchyProfileDirection {
+  const HierarchyProfileDirection({this.profileId = Order.ascending});
+
+  final Order profileId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [HierarchyProfile].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class HierarchyProfilePageRequest
+    implements PageRequest<HierarchyProfile, HierarchyProfileCursor> {
+  const HierarchyProfilePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const HierarchyProfileDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final HierarchyProfileCursor? cursor;
+
+  final HierarchyProfileDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(
+    Expr<HierarchyProfile> hierarchyProfile,
+  ) => [(hierarchyProfile.profileId, direction.profileId)];
+
+  @override
+  Expr<bool?> where(Expr<HierarchyProfile> hierarchyProfile) =>
+      direction.profileId == Order.ascending
+      ? hierarchyProfile.profileId > toExpr(cursor!.profileId)
+      : hierarchyProfile.profileId < toExpr(cursor!.profileId);
+
+  @override
+  HierarchyProfileCursor cursorOf(HierarchyProfile hierarchyProfile) =>
+      HierarchyProfileCursor(profileId: hierarchyProfile.profileId);
+
+  @override
+  HierarchyProfilePageRequest withCursor(HierarchyProfileCursor cursor) =>
+      HierarchyProfilePageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `hierarchyProfiles` table.
 extension QueryHierarchyProfileExt on Query<(Expr<HierarchyProfile>,)> {
   /// Lookup a single row in `hierarchyProfiles` table using the _primary key_.
@@ -868,6 +1025,30 @@ extension QueryHierarchyProfileExt on Query<(Expr<HierarchyProfile>,)> {
   QuerySingle<(Expr<HierarchyProfile>,)> byKey(int profileId) => where(
     (hierarchyProfile) => hierarchyProfile.profileId.equalsValue(profileId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<HierarchyProfile, HierarchyProfileCursor>? request =
+  ///     HierarchyProfilePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [HierarchyProfileCursor].
+  Future<Page<HierarchyProfile, HierarchyProfileCursor>> fetchPage(
+    PageRequest<HierarchyProfile, HierarchyProfileCursor> request,
+  ) => $ForGeneratedCode.fetchPage<HierarchyProfile, HierarchyProfileCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `hierarchyProfiles` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/overrides/legacy_names/legacy_names_test.g.dart
+++ b/typed_sql/test/typed_sql/overrides/legacy_names/legacy_names_test.g.dart
@@ -284,6 +284,90 @@ extension TableLegacyUserExt on Table<LegacyUser> {
       .deleteSingle(byKey(tenantId, userId), _$LegacyUser._$table);
 }
 
+/// Pagination cursor referencing a row in [LegacyUser].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class LegacyUserCursor {
+  const LegacyUserCursor({required this.tenantId, required this.userId});
+
+  final int tenantId;
+
+  final int userId;
+
+  @override
+  String toString() =>
+      'LegacyUserCursor(tenantId: "$tenantId", userId: "$userId")';
+}
+
+/// Sort direction for each _primary key_ field of [LegacyUser], used by
+/// `.fetchPage(...)`.
+final class LegacyUserDirection {
+  const LegacyUserDirection({
+    this.tenantId = Order.ascending,
+    this.userId = Order.ascending,
+  });
+
+  final Order tenantId;
+
+  final Order userId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [LegacyUser].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class LegacyUserPageRequest
+    implements PageRequest<LegacyUser, LegacyUserCursor> {
+  const LegacyUserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const LegacyUserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final LegacyUserCursor? cursor;
+
+  final LegacyUserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<LegacyUser> legacyUser) => [
+    (legacyUser.tenantId, direction.tenantId),
+    (legacyUser.userId, direction.userId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<LegacyUser> legacyUser) =>
+      (direction.tenantId == Order.ascending
+              ? legacyUser.tenantId > toExpr(cursor!.tenantId)
+              : legacyUser.tenantId < toExpr(cursor!.tenantId))
+          .or(
+            legacyUser.tenantId.equalsValue(cursor!.tenantId) &
+                (direction.userId == Order.ascending
+                    ? legacyUser.userId > toExpr(cursor!.userId)
+                    : legacyUser.userId < toExpr(cursor!.userId)),
+          );
+
+  @override
+  LegacyUserCursor cursorOf(LegacyUser legacyUser) => LegacyUserCursor(
+    tenantId: legacyUser.tenantId,
+    userId: legacyUser.userId,
+  );
+
+  @override
+  LegacyUserPageRequest withCursor(LegacyUserCursor cursor) =>
+      LegacyUserPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `users` table.
 extension QueryLegacyUserExt on Query<(Expr<LegacyUser>,)> {
   /// Lookup a single row in `users` table using the _primary key_.
@@ -295,6 +379,30 @@ extension QueryLegacyUserExt on Query<(Expr<LegacyUser>,)> {
         legacyUser.tenantId.equalsValue(tenantId) &
         legacyUser.userId.equalsValue(userId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<LegacyUser, LegacyUserCursor>? request =
+  ///     LegacyUserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [LegacyUserCursor].
+  Future<Page<LegacyUser, LegacyUserCursor>> fetchPage(
+    PageRequest<LegacyUser, LegacyUserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<LegacyUser, LegacyUserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `users` table matching this [Query].
   ///
@@ -898,6 +1006,72 @@ extension TableLegacyCommentExt on Table<LegacyComment> {
       $ForGeneratedCode.deleteSingle(byKey(commentId), _$LegacyComment._$table);
 }
 
+/// Pagination cursor referencing a row in [LegacyComment].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class LegacyCommentCursor {
+  const LegacyCommentCursor({required this.commentId});
+
+  final int commentId;
+
+  @override
+  String toString() => 'LegacyCommentCursor(commentId: "$commentId")';
+}
+
+/// Sort direction for each _primary key_ field of [LegacyComment], used by
+/// `.fetchPage(...)`.
+final class LegacyCommentDirection {
+  const LegacyCommentDirection({this.commentId = Order.ascending});
+
+  final Order commentId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [LegacyComment].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class LegacyCommentPageRequest
+    implements PageRequest<LegacyComment, LegacyCommentCursor> {
+  const LegacyCommentPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const LegacyCommentDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final LegacyCommentCursor? cursor;
+
+  final LegacyCommentDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<LegacyComment> legacyComment) =>
+      [(legacyComment.commentId, direction.commentId)];
+
+  @override
+  Expr<bool?> where(Expr<LegacyComment> legacyComment) =>
+      direction.commentId == Order.ascending
+      ? legacyComment.commentId > toExpr(cursor!.commentId)
+      : legacyComment.commentId < toExpr(cursor!.commentId);
+
+  @override
+  LegacyCommentCursor cursorOf(LegacyComment legacyComment) =>
+      LegacyCommentCursor(commentId: legacyComment.commentId);
+
+  @override
+  LegacyCommentPageRequest withCursor(LegacyCommentCursor cursor) =>
+      LegacyCommentPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `comments` table.
 extension QueryLegacyCommentExt on Query<(Expr<LegacyComment>,)> {
   /// Lookup a single row in `comments` table using the _primary key_.
@@ -907,6 +1081,30 @@ extension QueryLegacyCommentExt on Query<(Expr<LegacyComment>,)> {
   QuerySingle<(Expr<LegacyComment>,)> byKey(int commentId) => where(
     (legacyComment) => legacyComment.commentId.equalsValue(commentId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<LegacyComment, LegacyCommentCursor>? request =
+  ///     LegacyCommentPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [LegacyCommentCursor].
+  Future<Page<LegacyComment, LegacyCommentCursor>> fetchPage(
+    PageRequest<LegacyComment, LegacyCommentCursor> request,
+  ) => $ForGeneratedCode.fetchPage<LegacyComment, LegacyCommentCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `comments` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/overrides/schema_snake_case/schema_snake_case_test.g.dart
+++ b/typed_sql/test/typed_sql/overrides/schema_snake_case/schema_snake_case_test.g.dart
@@ -275,6 +275,73 @@ extension TableSnakeUserExt on Table<SnakeUser> {
       $ForGeneratedCode.deleteSingle(byKey(userId), _$SnakeUser._$table);
 }
 
+/// Pagination cursor referencing a row in [SnakeUser].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SnakeUserCursor {
+  const SnakeUserCursor({required this.userId});
+
+  final int userId;
+
+  @override
+  String toString() => 'SnakeUserCursor(userId: "$userId")';
+}
+
+/// Sort direction for each _primary key_ field of [SnakeUser], used by
+/// `.fetchPage(...)`.
+final class SnakeUserDirection {
+  const SnakeUserDirection({this.userId = Order.ascending});
+
+  final Order userId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SnakeUser].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SnakeUserPageRequest
+    implements PageRequest<SnakeUser, SnakeUserCursor> {
+  const SnakeUserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SnakeUserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SnakeUserCursor? cursor;
+
+  final SnakeUserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SnakeUser> snakeUser) => [
+    (snakeUser.userId, direction.userId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SnakeUser> snakeUser) =>
+      direction.userId == Order.ascending
+      ? snakeUser.userId > toExpr(cursor!.userId)
+      : snakeUser.userId < toExpr(cursor!.userId);
+
+  @override
+  SnakeUserCursor cursorOf(SnakeUser snakeUser) =>
+      SnakeUserCursor(userId: snakeUser.userId);
+
+  @override
+  SnakeUserPageRequest withCursor(SnakeUserCursor cursor) =>
+      SnakeUserPageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `snakeUsers` table.
 extension QuerySnakeUserExt on Query<(Expr<SnakeUser>,)> {
   /// Lookup a single row in `snakeUsers` table using the _primary key_.
@@ -283,6 +350,30 @@ extension QuerySnakeUserExt on Query<(Expr<SnakeUser>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<SnakeUser>,)> byKey(int userId) =>
       where((snakeUser) => snakeUser.userId.equalsValue(userId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SnakeUser, SnakeUserCursor>? request =
+  ///     SnakeUserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SnakeUserCursor].
+  Future<Page<SnakeUser, SnakeUserCursor>> fetchPage(
+    PageRequest<SnakeUser, SnakeUserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SnakeUser, SnakeUserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `snakeUsers` table matching this [Query].
   ///
@@ -865,6 +956,73 @@ extension TableSnakeProfileExt on Table<SnakeProfile> {
       $ForGeneratedCode.deleteSingle(byKey(profileId), _$SnakeProfile._$table);
 }
 
+/// Pagination cursor referencing a row in [SnakeProfile].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class SnakeProfileCursor {
+  const SnakeProfileCursor({required this.profileId});
+
+  final int profileId;
+
+  @override
+  String toString() => 'SnakeProfileCursor(profileId: "$profileId")';
+}
+
+/// Sort direction for each _primary key_ field of [SnakeProfile], used by
+/// `.fetchPage(...)`.
+final class SnakeProfileDirection {
+  const SnakeProfileDirection({this.profileId = Order.ascending});
+
+  final Order profileId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [SnakeProfile].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class SnakeProfilePageRequest
+    implements PageRequest<SnakeProfile, SnakeProfileCursor> {
+  const SnakeProfilePageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const SnakeProfileDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final SnakeProfileCursor? cursor;
+
+  final SnakeProfileDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<SnakeProfile> snakeProfile) => [
+    (snakeProfile.profileId, direction.profileId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<SnakeProfile> snakeProfile) =>
+      direction.profileId == Order.ascending
+      ? snakeProfile.profileId > toExpr(cursor!.profileId)
+      : snakeProfile.profileId < toExpr(cursor!.profileId);
+
+  @override
+  SnakeProfileCursor cursorOf(SnakeProfile snakeProfile) =>
+      SnakeProfileCursor(profileId: snakeProfile.profileId);
+
+  @override
+  SnakeProfilePageRequest withCursor(SnakeProfileCursor cursor) =>
+      SnakeProfilePageRequest(
+        pageSize: pageSize,
+        cursor: cursor,
+        direction: direction,
+      );
+}
+
 /// Extension methods for building queries against the `snakeProfiles` table.
 extension QuerySnakeProfileExt on Query<(Expr<SnakeProfile>,)> {
   /// Lookup a single row in `snakeProfiles` table using the _primary key_.
@@ -874,6 +1032,30 @@ extension QuerySnakeProfileExt on Query<(Expr<SnakeProfile>,)> {
   QuerySingle<(Expr<SnakeProfile>,)> byKey(int profileId) => where(
     (snakeProfile) => snakeProfile.profileId.equalsValue(profileId),
   ).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<SnakeProfile, SnakeProfileCursor>? request =
+  ///     SnakeProfilePageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [SnakeProfileCursor].
+  Future<Page<SnakeProfile, SnakeProfileCursor>> fetchPage(
+    PageRequest<SnakeProfile, SnakeProfileCursor> request,
+  ) => $ForGeneratedCode.fetchPage<SnakeProfile, SnakeProfileCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `snakeProfiles` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/pagination/fetch_page_basic/fetch_page_basic_test.dart
+++ b/typed_sql/test/typed_sql/pagination/fetch_page_basic/fetch_page_basic_test.dart
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+
+import '../../testrunner.dart';
+
+part 'fetch_page_basic_test.g.dart';
+
+abstract final class TestDatabase extends Schema {
+  Table<Item> get items;
+}
+
+@PrimaryKey(['id'])
+abstract final class Item extends Row {
+  @AutoIncrement()
+  int get id;
+
+  String get name;
+  int get value;
+}
+
+void main() {
+  final r = TestRunner<TestDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  Future<void> insertItems(Database<TestDatabase> db, int count) async {
+    for (var i = 1; i <= count; i++) {
+      await db.items
+          .insertValue(id: i, name: 'item-$i', value: i * 10)
+          .execute();
+    }
+  }
+
+  r.addTest('.fetchPage() on an empty table', (db) async {
+    final page = await db.items.fetchPage(const ItemPageRequest(pageSize: 10));
+    check(page.items).isEmpty();
+    check(page.hasMore).isFalse();
+    check(page.nextCursor).isNull();
+    check(page.nextPageRequest).isNull();
+  });
+
+  r.addTest(
+    '.fetchPage() walks all rows, exact multiple of pageSize',
+    (db) async {
+      await insertItems(db, 20);
+
+      final page1 = await db.items.fetchPage(
+        const ItemPageRequest(pageSize: 10),
+      );
+      check(page1.items.map((i) => i.id).toList()).deepEquals(
+        List.generate(10, (i) => i + 1),
+      );
+      check(page1.hasMore).isTrue();
+      check(page1.nextCursor).isNotNull();
+      check(page1.nextPageRequest).isNotNull();
+
+      final page2 = await db.items.fetchPage(page1.nextPageRequest!);
+      check(page2.items.map((i) => i.id).toList()).deepEquals(
+        List.generate(10, (i) => i + 11),
+      );
+      check(page2.hasMore).isFalse();
+      check(page2.nextCursor).isNull();
+      check(page2.nextPageRequest).isNull();
+    },
+  );
+
+  r.addTest(
+    '.fetchPage() walks all rows, non-exact multiple of pageSize',
+    (db) async {
+      await insertItems(db, 25);
+
+      final seen = <int>[];
+      PageRequest<Item, ItemCursor>? request = const ItemPageRequest(
+        pageSize: 10,
+      );
+      while (request != null) {
+        final page = await db.items.fetchPage(request);
+        seen.addAll(page.items.map((i) => i.id));
+        request = page.nextPageRequest;
+      }
+      check(seen).deepEquals(List.generate(25, (i) => i + 1));
+    },
+  );
+
+  r.addTest('.fetchPage() with pageSize larger than row count', (db) async {
+    await insertItems(db, 5);
+
+    final page = await db.items.fetchPage(const ItemPageRequest(pageSize: 100));
+    check(page.items).length.equals(5);
+    check(page.hasMore).isFalse();
+    check(page.nextCursor).isNull();
+    check(page.nextPageRequest).isNull();
+  });
+
+  r.addTest('.fetchPage() composes with .where()', (db) async {
+    await insertItems(db, 10);
+
+    final page = await db.items
+        .where((i) => i.value > 50.asExpr)
+        .fetchPage(const ItemPageRequest(pageSize: 3));
+    check(page.items.map((i) => i.id).toList()).deepEquals([6, 7, 8]);
+    check(page.hasMore).isTrue();
+  });
+
+  r.addTest(
+    '.fetchPage() cursor is stable under concurrent inserts',
+    (db) async {
+      await insertItems(db, 5); // ids 1..5
+
+      final page1 = await db.items.fetchPage(
+        const ItemPageRequest(pageSize: 3),
+      );
+      check(page1.items.map((i) => i.id).toList()).deepEquals([1, 2, 3]);
+      final cursor = page1.nextCursor;
+      check(cursor).isNotNull();
+
+      // Insert a row before the cursor -- must not reappear on the next page.
+      //
+      // Uses a negative id rather than 0: MySQL/MariaDB treats a literal `0`
+      // in an AUTO_INCREMENT column the same as `NULL` (i.e. "auto-assign"),
+      // so it wouldn't actually land before the cursor there.
+      await db.items.insertValue(id: -1, name: 'before', value: 0).execute();
+      // Insert a row after all existing rows -- must appear on the next page.
+      await db.items.insertValue(id: 100, name: 'after', value: 100).execute();
+
+      final page2 = await db.items.fetchPage(page1.nextPageRequest!);
+      check(page2.items.map((i) => i.id).toList()).deepEquals([4, 5, 100]);
+      check(page2.hasMore).isFalse();
+    },
+  );
+
+  r.addTest(
+    '.fetchPage() cursor extracted from a page can be serialized and '
+    'reconstructed to resume pagination independently of nextPageRequest',
+    (db) async {
+      await insertItems(db, 10);
+
+      final page1 = await db.items.fetchPage(
+        const ItemPageRequest(pageSize: 4),
+      );
+      final cursor = page1.nextCursor!;
+
+      // Simulate persisting just the cursor's own field (e.g. in a URL) and
+      // reconstructing it later using the cursor's own const constructor,
+      // rather than keeping the original cursor or PageRequest object alive.
+      final serialized = cursor.id;
+      final reconstructed = ItemCursor(id: serialized);
+
+      final resumed = await db.items.fetchPage(
+        ItemPageRequest(pageSize: 4, cursor: reconstructed),
+      );
+      check(resumed.items.map((i) => i.id).toList()).deepEquals([5, 6, 7, 8]);
+    },
+  );
+
+  r.addTest('.fetchPage() throws for non-positive pageSize', (db) async {
+    await check(
+      db.items.fetchPage(const ItemPageRequest(pageSize: 0)),
+    ).throws<ArgumentError>();
+    await check(
+      db.items.fetchPage(const ItemPageRequest(pageSize: -1)),
+    ).throws<ArgumentError>();
+  });
+
+  r.addTest('.fetchPage() with a descending direction', (db) async {
+    await insertItems(db, 10);
+
+    final page1 = await db.items.fetchPage(
+      const ItemPageRequest(
+        pageSize: 4,
+        direction: ItemDirection(id: Order.descending),
+      ),
+    );
+    check(page1.items.map((i) => i.id).toList()).deepEquals([10, 9, 8, 7]);
+    check(page1.hasMore).isTrue();
+
+    // `nextPageRequest` carries `pageSize` (4) forward too, so walk the rest.
+    final seen = <int>[];
+    var request = page1.nextPageRequest;
+    while (request != null) {
+      final page = await db.items.fetchPage(request);
+      seen.addAll(page.items.map((i) => i.id));
+      request = page.nextPageRequest;
+    }
+    check(seen).deepEquals([6, 5, 4, 3, 2, 1]);
+  });
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/pagination/fetch_page_basic/fetch_page_basic_test.g.dart
+++ b/typed_sql/test/typed_sql/pagination/fetch_page_basic/fetch_page_basic_test.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'distinct_model_test.dart';
+part of 'fetch_page_basic_test.dart';
 
 // **************************************************************************
 // Generator: _TypedSqlBuilder
@@ -43,26 +43,20 @@ String createTestDatabaseTables(SqlDialect dialect) => $ForGeneratedCode
     .createTableSchema(dialect: dialect, tables: TestDatabaseSchema._$tables);
 
 final class _$Item extends Item {
-  _$Item._(this.id, this.text, this.integer, this.real, this.json);
+  _$Item._(this.id, this.name, this.value);
 
   @override
   final int id;
 
   @override
-  final String text;
+  final String name;
 
   @override
-  final int integer;
-
-  @override
-  final double real;
-
-  @override
-  final JsonValue json;
+  final int value;
 
   static final _$table = $ForGeneratedCode.tableDefinition(
     tableName: 'items',
-    columns: <String>['id', 'text', 'integer', 'real', 'json'],
+    columns: <String>['id', 'name', 'value'],
     columnInfo: [
       $ForGeneratedCode.columnDefinition(
         type: $ForGeneratedCode.integer,
@@ -85,20 +79,6 @@ final class _$Item extends Item {
         autoIncrement: false,
         overrides: [],
       ),
-      $ForGeneratedCode.columnDefinition(
-        type: $ForGeneratedCode.real,
-        isNotNull: true,
-        defaultValue: null,
-        autoIncrement: false,
-        overrides: [],
-      ),
-      $ForGeneratedCode.columnDefinition(
-        type: $ForGeneratedCode.jsonValue,
-        isNotNull: true,
-        defaultValue: null,
-        autoIncrement: false,
-        overrides: [],
-      ),
     ],
     primaryKey: <String>['id'],
     unique: <List<String>>[],
@@ -109,23 +89,16 @@ final class _$Item extends Item {
 
   static Item? _$fromDatabase(RowReader row) {
     final id = row.readInt();
-    final text = row.readString();
-    final integer = row.readInt();
-    final real = row.readDouble();
-    final json = row.readJsonValue();
-    if (id == null &&
-        text == null &&
-        integer == null &&
-        real == null &&
-        json == null) {
+    final name = row.readString();
+    final value = row.readInt();
+    if (id == null && name == null && value == null) {
       return null;
     }
-    return _$Item._(id!, text!, integer!, real!, json!);
+    return _$Item._(id!, name!, value!);
   }
 
   @override
-  String toString() =>
-      'Item(id: "$id", text: "$text", integer: "$integer", real: "$real", json: "$json")';
+  String toString() => 'Item(id: "$id", name: "$name", value: "$value")';
 }
 
 /// Extension methods for table defined in [Item].
@@ -136,14 +109,9 @@ extension TableItemExt on Table<Item> {
   /// called for the row to be inserted.
   InsertSingle<Item> insert({
     Expr<int>? id,
-    required Expr<String> text,
-    required Expr<int> integer,
-    required Expr<double> real,
-    required Expr<JsonValue> json,
-  }) => $ForGeneratedCode.insertInto(
-    table: this,
-    values: [id, text, integer, real, json],
-  );
+    required Expr<String> name,
+    required Expr<int> value,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, value]);
 
   /// Insert row into the `items` table.
   ///
@@ -151,13 +119,11 @@ extension TableItemExt on Table<Item> {
   /// called for the row to be inserted.
   InsertSingle<Item> insertValue({
     int? id,
-    required String text,
-    required int integer,
-    required double real,
-    required JsonValue json,
+    required String name,
+    required int value,
   }) => $ForGeneratedCode.insertInto(
     table: this,
-    values: [id?.asExpr, text.asExpr, integer.asExpr, real.asExpr, json.asExpr],
+    values: [id?.asExpr, name.asExpr, value.asExpr],
   );
 
   /// Bulk insert rows into the `items` table.
@@ -180,14 +146,12 @@ extension TableItemExt on Table<Item> {
   Insert<Item> insertValuesMapped<T>(
     Iterable<T> rows, {
     int Function(T row)? id,
-    required String Function(T row) text,
-    required int Function(T row) integer,
-    required double Function(T row) real,
-    required JsonValue Function(T row) json,
+    required String Function(T row) name,
+    required int Function(T row) value,
   }) => $ForGeneratedCode.insertValuesMapped(
     table: this,
     rows: rows,
-    mappings: [id, text, integer, real, json],
+    mappings: [id, name, value],
   );
 
   /// Delete a single row from the `items` table, specified by
@@ -328,10 +292,8 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
       Expr<Item> item,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<int> value,
       })
       set,
     )
@@ -341,14 +303,8 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
     _$Item._$table,
     (item) => updateBuilder(
       item,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<int>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 
@@ -395,10 +351,8 @@ extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
       Expr<Item> item,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<int> value,
       })
       set,
     )
@@ -408,14 +362,8 @@ extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
     _$Item._$table,
     (item) => updateBuilder(
       item,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<int>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 
@@ -433,34 +381,22 @@ extension ExpressionItemExt on Expr<Item> {
   Expr<int> get id =>
       $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
 
-  Expr<String> get text =>
+  Expr<String> get name =>
       $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
 
-  Expr<int> get integer =>
+  Expr<int> get value =>
       $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
-
-  Expr<double> get real =>
-      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.real);
-
-  Expr<JsonValue> get json =>
-      $ForGeneratedCode.field(this, 4, $ForGeneratedCode.jsonValue);
 }
 
 extension ExpressionNullableItemExt on Expr<Item?> {
   Expr<int?> get id =>
       $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
 
-  Expr<String?> get text =>
+  Expr<String?> get name =>
       $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
 
-  Expr<int?> get integer =>
+  Expr<int?> get value =>
       $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
-
-  Expr<double?> get real =>
-      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.real);
-
-  Expr<JsonValue?> get json =>
-      $ForGeneratedCode.field(this, 4, $ForGeneratedCode.jsonValue);
 
   /// Check if the row is not `NULL`.
   ///
@@ -561,10 +497,8 @@ extension InsertOnConflictItemExt on InsertOnConflict<Item> {
       Expr<Item> excluded,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<int> value,
       })
       set,
     )
@@ -574,14 +508,8 @@ extension InsertOnConflictItemExt on InsertOnConflict<Item> {
     (item, excluded) => updateBuilder(
       item,
       excluded,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<int>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 }
@@ -655,10 +583,8 @@ extension InsertOnConflictSingleItemExt on InsertOnConflictSingle<Item> {
       Expr<Item> excluded,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<int> value,
       })
       set,
     )
@@ -668,14 +594,8 @@ extension InsertOnConflictSingleItemExt on InsertOnConflictSingle<Item> {
     (item, excluded) => updateBuilder(
       item,
       excluded,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<int>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 }
@@ -688,15 +608,9 @@ extension ItemChecks on Subject<Item> {
   /// Create assertions on [Item.id].
   Subject<int> get id => has((m) => m.id, 'id');
 
-  /// Create assertions on [Item.text].
-  Subject<String> get text => has((m) => m.text, 'text');
+  /// Create assertions on [Item.name].
+  Subject<String> get name => has((m) => m.name, 'name');
 
-  /// Create assertions on [Item.integer].
-  Subject<int> get integer => has((m) => m.integer, 'integer');
-
-  /// Create assertions on [Item.real].
-  Subject<double> get real => has((m) => m.real, 'real');
-
-  /// Create assertions on [Item.json].
-  Subject<JsonValue> get json => has((m) => m.json, 'json');
+  /// Create assertions on [Item.value].
+  Subject<int> get value => has((m) => m.value, 'value');
 }

--- a/typed_sql/test/typed_sql/pagination/fetch_page_composite_key/fetch_page_composite_key_test.dart
+++ b/typed_sql/test/typed_sql/pagination/fetch_page_composite_key/fetch_page_composite_key_test.dart
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:typed_sql/typed_sql.dart';
+
+import '../../testrunner.dart';
+
+part 'fetch_page_composite_key_test.g.dart';
+
+abstract final class TestDatabase extends Schema {
+  Table<Item> get items;
+}
+
+@PrimaryKey(['id', 'name'])
+abstract final class Item extends Row {
+  int get id;
+
+  @SqlOverride.field(dialect: 'mysql', columnType: 'VARCHAR(255)')
+  String get name;
+
+  String? get value;
+}
+
+// Repeated `id` values with distinct `name`s, so page boundaries can land
+// mid-group and exercise the `id == cursor.id & name > cursor.name`
+// (or `<` for descending) tie-breaking term, not just the leading
+// `id > cursor.id` term.
+const _keys = [
+  (id: 1, name: 'a'),
+  (id: 1, name: 'b'),
+  (id: 1, name: 'c'),
+  (id: 2, name: 'a'),
+  (id: 2, name: 'b'),
+];
+
+void main() {
+  final r = TestRunner<TestDatabase>(
+    setup: (db) async {
+      await db.createTables();
+    },
+  );
+
+  Future<void> insertKeys(Database<TestDatabase> db) async {
+    for (final k in _keys) {
+      await db.items.insert(id: toExpr(k.id), name: toExpr(k.name)).execute();
+    }
+  }
+
+  r.addTest(
+    '.fetchPage() walks a composite key across group boundaries',
+    (db) async {
+      await insertKeys(db);
+
+      final page1 = await db.items.fetchPage(
+        const ItemPageRequest(pageSize: 2),
+      );
+      check(page1.items.map((i) => (i.id, i.name)).toList()).deepEquals([
+        (1, 'a'),
+        (1, 'b'),
+      ]);
+      check(page1.hasMore).isTrue();
+
+      final page2 = await db.items.fetchPage(page1.nextPageRequest!);
+      check(page2.items.map((i) => (i.id, i.name)).toList()).deepEquals([
+        (1, 'c'),
+        (2, 'a'),
+      ]);
+      check(page2.hasMore).isTrue();
+
+      final page3 = await db.items.fetchPage(page2.nextPageRequest!);
+      check(page3.items.map((i) => (i.id, i.name)).toList()).deepEquals([
+        (2, 'b'),
+      ]);
+      check(page3.hasMore).isFalse();
+      check(page3.nextCursor).isNull();
+      check(page3.nextPageRequest).isNull();
+    },
+  );
+
+  r.addTest(
+    '.fetchPage() full walk matches an unpaginated .orderBy()',
+    (db) async {
+      await insertKeys(db);
+
+      final expected = await db.items
+          .orderBy((i) => [(i.id, .ascending), (i.name, .ascending)])
+          .select((i) => (i.id, i.name))
+          .fetch();
+
+      final seen = <(int, String)>[];
+      PageRequest<Item, ItemCursor>? request = const ItemPageRequest(
+        pageSize: 2,
+      );
+      while (request != null) {
+        final page = await db.items.fetchPage(request);
+        seen.addAll(page.items.map((i) => (i.id, i.name)));
+        request = page.nextPageRequest;
+      }
+      check(seen).deepEquals(expected);
+    },
+  );
+
+  r.addTest(
+    '.fetchPage() cursor round-trips through its fields, independently of '
+    'nextPageRequest',
+    (db) async {
+      await insertKeys(db);
+
+      final page1 = await db.items.fetchPage(
+        const ItemPageRequest(pageSize: 2),
+      );
+      final cursor = page1.nextCursor;
+      check(cursor).isNotNull();
+
+      // Simulate persisting the cursor's fields (e.g. in a URL) and
+      // reconstructing it later, rather than keeping the original cursor or
+      // PageRequest object around.
+      final reconstructed = ItemCursor(id: cursor!.id, name: cursor.name);
+
+      final expected = await db.items.fetchPage(page1.nextPageRequest!);
+      final actual = await db.items.fetchPage(
+        ItemPageRequest(pageSize: 2, cursor: reconstructed),
+      );
+      check(actual.items.map((i) => (i.id, i.name)).toList()).deepEquals(
+        expected.items.map((i) => (i.id, i.name)).toList(),
+      );
+    },
+  );
+
+  r.addTest(
+    '.fetchPage() with independent per-field directions (id asc, name desc)',
+    (db) async {
+      await insertKeys(db);
+
+      final expected = await db.items
+          .orderBy((i) => [(i.id, .ascending), (i.name, .descending)])
+          .select((i) => (i.id, i.name))
+          .fetch();
+
+      final seen = <(int, String)>[];
+      PageRequest<Item, ItemCursor>? request = const ItemPageRequest(
+        pageSize: 2,
+        direction: ItemDirection(name: Order.descending),
+      );
+      while (request != null) {
+        final page = await db.items.fetchPage(request);
+        seen.addAll(page.items.map((i) => (i.id, i.name)));
+        request = page.nextPageRequest;
+      }
+      check(seen).deepEquals(expected);
+    },
+  );
+
+  r.run();
+}

--- a/typed_sql/test/typed_sql/pagination/fetch_page_composite_key/fetch_page_composite_key_test.g.dart
+++ b/typed_sql/test/typed_sql/pagination/fetch_page_composite_key/fetch_page_composite_key_test.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'distinct_model_test.dart';
+part of 'fetch_page_composite_key_test.dart';
 
 // **************************************************************************
 // Generator: _TypedSqlBuilder
@@ -43,32 +43,26 @@ String createTestDatabaseTables(SqlDialect dialect) => $ForGeneratedCode
     .createTableSchema(dialect: dialect, tables: TestDatabaseSchema._$tables);
 
 final class _$Item extends Item {
-  _$Item._(this.id, this.text, this.integer, this.real, this.json);
+  _$Item._(this.id, this.name, this.value);
 
   @override
   final int id;
 
   @override
-  final String text;
+  final String name;
 
   @override
-  final int integer;
-
-  @override
-  final double real;
-
-  @override
-  final JsonValue json;
+  final String? value;
 
   static final _$table = $ForGeneratedCode.tableDefinition(
     tableName: 'items',
-    columns: <String>['id', 'text', 'integer', 'real', 'json'],
+    columns: <String>['id', 'name', 'value'],
     columnInfo: [
       $ForGeneratedCode.columnDefinition(
         type: $ForGeneratedCode.integer,
         isNotNull: true,
         defaultValue: null,
-        autoIncrement: true,
+        autoIncrement: false,
         overrides: [],
       ),
       $ForGeneratedCode.columnDefinition(
@@ -76,31 +70,24 @@ final class _$Item extends Item {
         isNotNull: true,
         defaultValue: null,
         autoIncrement: false,
-        overrides: [],
+        overrides: [
+          (
+            dialect: 'mysql',
+            columnType: 'VARCHAR(255)',
+            defaultValue: null,
+            collation: null,
+          ),
+        ],
       ),
       $ForGeneratedCode.columnDefinition(
-        type: $ForGeneratedCode.integer,
-        isNotNull: true,
-        defaultValue: null,
-        autoIncrement: false,
-        overrides: [],
-      ),
-      $ForGeneratedCode.columnDefinition(
-        type: $ForGeneratedCode.real,
-        isNotNull: true,
-        defaultValue: null,
-        autoIncrement: false,
-        overrides: [],
-      ),
-      $ForGeneratedCode.columnDefinition(
-        type: $ForGeneratedCode.jsonValue,
-        isNotNull: true,
+        type: $ForGeneratedCode.text,
+        isNotNull: false,
         defaultValue: null,
         autoIncrement: false,
         overrides: [],
       ),
     ],
-    primaryKey: <String>['id'],
+    primaryKey: <String>['id', 'name'],
     unique: <List<String>>[],
     foreignKeys: [],
     indexes: [],
@@ -109,23 +96,16 @@ final class _$Item extends Item {
 
   static Item? _$fromDatabase(RowReader row) {
     final id = row.readInt();
-    final text = row.readString();
-    final integer = row.readInt();
-    final real = row.readDouble();
-    final json = row.readJsonValue();
-    if (id == null &&
-        text == null &&
-        integer == null &&
-        real == null &&
-        json == null) {
+    final name = row.readString();
+    final value = row.readString();
+    if (id == null && name == null && value == null) {
       return null;
     }
-    return _$Item._(id!, text!, integer!, real!, json!);
+    return _$Item._(id!, name!, value);
   }
 
   @override
-  String toString() =>
-      'Item(id: "$id", text: "$text", integer: "$integer", real: "$real", json: "$json")';
+  String toString() => 'Item(id: "$id", name: "$name", value: "$value")';
 }
 
 /// Extension methods for table defined in [Item].
@@ -135,29 +115,22 @@ extension TableItemExt on Table<Item> {
   /// Returns a [InsertSingle] statement on which `.execute` must be
   /// called for the row to be inserted.
   InsertSingle<Item> insert({
-    Expr<int>? id,
-    required Expr<String> text,
-    required Expr<int> integer,
-    required Expr<double> real,
-    required Expr<JsonValue> json,
-  }) => $ForGeneratedCode.insertInto(
-    table: this,
-    values: [id, text, integer, real, json],
-  );
+    required Expr<int> id,
+    required Expr<String> name,
+    Expr<String?>? value,
+  }) => $ForGeneratedCode.insertInto(table: this, values: [id, name, value]);
 
   /// Insert row into the `items` table.
   ///
   /// Returns a [InsertSingle] statement on which `.execute` must be
   /// called for the row to be inserted.
   InsertSingle<Item> insertValue({
-    int? id,
-    required String text,
-    required int integer,
-    required double real,
-    required JsonValue json,
+    required int id,
+    required String name,
+    String? value,
   }) => $ForGeneratedCode.insertInto(
     table: this,
-    values: [id?.asExpr, text.asExpr, integer.asExpr, real.asExpr, json.asExpr],
+    values: [id.asExpr, name.asExpr, value.asExpr],
   );
 
   /// Bulk insert rows into the `items` table.
@@ -179,15 +152,13 @@ extension TableItemExt on Table<Item> {
   /// called for the rows to be inserted.
   Insert<Item> insertValuesMapped<T>(
     Iterable<T> rows, {
-    int Function(T row)? id,
-    required String Function(T row) text,
-    required int Function(T row) integer,
-    required double Function(T row) real,
-    required JsonValue Function(T row) json,
+    required int Function(T row) id,
+    required String Function(T row) name,
+    String? Function(T row)? value,
   }) => $ForGeneratedCode.insertValuesMapped(
     table: this,
     rows: rows,
-    mappings: [id, text, integer, real, json],
+    mappings: [id, name, value],
   );
 
   /// Delete a single row from the `items` table, specified by
@@ -199,8 +170,8 @@ extension TableItemExt on Table<Item> {
   /// To delete multiple rows, using `.where()` to filter which rows
   /// should be deleted. If you wish to delete all rows, use
   /// `.where((_) => toExpr(true)).delete()`.
-  DeleteSingle<Item> delete(int id) =>
-      $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
+  DeleteSingle<Item> delete(int id, String name) =>
+      $ForGeneratedCode.deleteSingle(byKey(id, name), _$Item._$table);
 }
 
 /// Pagination cursor referencing a row in [Item].
@@ -208,20 +179,24 @@ extension TableItemExt on Table<Item> {
 /// This identifies the row after which the next page of results begins,
 /// using the values of the _primary key_ fields from that row.
 final class ItemCursor {
-  const ItemCursor({required this.id});
+  const ItemCursor({required this.id, required this.name});
 
   final int id;
 
+  final String name;
+
   @override
-  String toString() => 'ItemCursor(id: "$id")';
+  String toString() => 'ItemCursor(id: "$id", name: "$name")';
 }
 
 /// Sort direction for each _primary key_ field of [Item], used by
 /// `.fetchPage(...)`.
 final class ItemDirection {
-  const ItemDirection({this.id = Order.ascending});
+  const ItemDirection({this.id = Order.ascending, this.name = Order.ascending});
 
   final Order id;
+
+  final Order name;
 }
 
 /// Parameters for a `.fetchPage(...)` call against [Item].
@@ -248,15 +223,23 @@ final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
   @override
   List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
     (item.id, direction.id),
+    (item.name, direction.name),
   ];
 
   @override
-  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
-      ? item.id > toExpr(cursor!.id)
-      : item.id < toExpr(cursor!.id);
+  Expr<bool?> where(Expr<Item> item) =>
+      (direction.id == Order.ascending
+              ? item.id > toExpr(cursor!.id)
+              : item.id < toExpr(cursor!.id))
+          .or(
+            item.id.equalsValue(cursor!.id) &
+                (direction.name == Order.ascending
+                    ? item.name > toExpr(cursor!.name)
+                    : item.name < toExpr(cursor!.name)),
+          );
 
   @override
-  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id, name: item.name);
 
   @override
   ItemPageRequest withCursor(ItemCursor cursor) =>
@@ -269,8 +252,9 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   ///
   /// Returns a [QuerySingle] object, which returns at-most one row,
   /// when `.fetch()` is called.
-  QuerySingle<(Expr<Item>,)> byKey(int id) =>
-      where((item) => item.id.equalsValue(id)).first;
+  QuerySingle<(Expr<Item>,)> byKey(int id, String name) => where(
+    (item) => item.id.equalsValue(id) & item.name.equalsValue(name),
+  ).first;
 
   /// Fetch a page of at most `request.pageSize` rows.
   ///
@@ -328,10 +312,8 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
       Expr<Item> item,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<String?> value,
       })
       set,
     )
@@ -341,14 +323,8 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
     _$Item._$table,
     (item) => updateBuilder(
       item,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 
@@ -395,10 +371,8 @@ extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
       Expr<Item> item,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<String?> value,
       })
       set,
     )
@@ -408,14 +382,8 @@ extension QuerySingleItemExt on QuerySingle<(Expr<Item>,)> {
     _$Item._$table,
     (item) => updateBuilder(
       item,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 
@@ -433,34 +401,22 @@ extension ExpressionItemExt on Expr<Item> {
   Expr<int> get id =>
       $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
 
-  Expr<String> get text =>
+  Expr<String> get name =>
       $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
 
-  Expr<int> get integer =>
-      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
-
-  Expr<double> get real =>
-      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.real);
-
-  Expr<JsonValue> get json =>
-      $ForGeneratedCode.field(this, 4, $ForGeneratedCode.jsonValue);
+  Expr<String?> get value =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
 }
 
 extension ExpressionNullableItemExt on Expr<Item?> {
   Expr<int?> get id =>
       $ForGeneratedCode.field(this, 0, $ForGeneratedCode.integer);
 
-  Expr<String?> get text =>
+  Expr<String?> get name =>
       $ForGeneratedCode.field(this, 1, $ForGeneratedCode.text);
 
-  Expr<int?> get integer =>
-      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.integer);
-
-  Expr<double?> get real =>
-      $ForGeneratedCode.field(this, 3, $ForGeneratedCode.real);
-
-  Expr<JsonValue?> get json =>
-      $ForGeneratedCode.field(this, 4, $ForGeneratedCode.jsonValue);
+  Expr<String?> get value =>
+      $ForGeneratedCode.field(this, 2, $ForGeneratedCode.text);
 
   /// Check if the row is not `NULL`.
   ///
@@ -468,7 +424,7 @@ extension ExpressionNullableItemExt on Expr<Item?> {
   ///
   /// If this is a reference lookup by subquery it might be more efficient
   /// to check if the referencing field is `NULL`.
-  Expr<bool> isNotNull() => id.isNotNull();
+  Expr<bool> isNotNull() => id.isNotNull() & name.isNotNull();
 
   /// Check if the row is `NULL`.
   ///
@@ -484,8 +440,8 @@ enum ItemConflict {
   /// Conflict with an existing row that has a matching primary key.
   ///
   /// Thus, the other row has matching values for:
-  /// `id`.
-  primaryKey(['id']);
+  /// `id`, `name`.
+  primaryKey(['id', 'name']);
 
   const ItemConflict(this._fields);
 
@@ -561,10 +517,8 @@ extension InsertOnConflictItemExt on InsertOnConflict<Item> {
       Expr<Item> excluded,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<String?> value,
       })
       set,
     )
@@ -574,14 +528,8 @@ extension InsertOnConflictItemExt on InsertOnConflict<Item> {
     (item, excluded) => updateBuilder(
       item,
       excluded,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 }
@@ -655,10 +603,8 @@ extension InsertOnConflictSingleItemExt on InsertOnConflictSingle<Item> {
       Expr<Item> excluded,
       UpdateSet<Item> Function({
         Expr<int> id,
-        Expr<String> text,
-        Expr<int> integer,
-        Expr<double> real,
-        Expr<JsonValue> json,
+        Expr<String> name,
+        Expr<String?> value,
       })
       set,
     )
@@ -668,14 +614,8 @@ extension InsertOnConflictSingleItemExt on InsertOnConflictSingle<Item> {
     (item, excluded) => updateBuilder(
       item,
       excluded,
-      ({
-        Expr<int>? id,
-        Expr<String>? text,
-        Expr<int>? integer,
-        Expr<double>? real,
-        Expr<JsonValue>? json,
-      }) =>
-          $ForGeneratedCode.buildUpdate<Item>([id, text, integer, real, json]),
+      ({Expr<int>? id, Expr<String>? name, Expr<String?>? value}) =>
+          $ForGeneratedCode.buildUpdate<Item>([id, name, value]),
     ),
   );
 }
@@ -688,15 +628,9 @@ extension ItemChecks on Subject<Item> {
   /// Create assertions on [Item.id].
   Subject<int> get id => has((m) => m.id, 'id');
 
-  /// Create assertions on [Item.text].
-  Subject<String> get text => has((m) => m.text, 'text');
+  /// Create assertions on [Item.name].
+  Subject<String> get name => has((m) => m.name, 'name');
 
-  /// Create assertions on [Item.integer].
-  Subject<int> get integer => has((m) => m.integer, 'integer');
-
-  /// Create assertions on [Item.real].
-  Subject<double> get real => has((m) => m.real, 'real');
-
-  /// Create assertions on [Item.json].
-  Subject<JsonValue> get json => has((m) => m.json, 'json');
+  /// Create assertions on [Item.value].
+  Subject<String?> get value => has((m) => m.value, 'value');
 }

--- a/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
+++ b/typed_sql/test/typed_sql/references/nullable_reference/nullable_reference_test.g.dart
@@ -183,6 +183,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -191,6 +256,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -866,6 +955,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -874,6 +1023,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
+++ b/typed_sql/test/typed_sql/references/references_id_as/references_id_as_test.g.dart
@@ -174,6 +174,71 @@ extension TableAuthorExt on Table<Author> {
       $ForGeneratedCode.deleteSingle(byKey(authorId), _$Author._$table);
 }
 
+/// Pagination cursor referencing a row in [Author].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AuthorCursor {
+  const AuthorCursor({required this.authorId});
+
+  final int authorId;
+
+  @override
+  String toString() => 'AuthorCursor(authorId: "$authorId")';
+}
+
+/// Sort direction for each _primary key_ field of [Author], used by
+/// `.fetchPage(...)`.
+final class AuthorDirection {
+  const AuthorDirection({this.authorId = Order.ascending});
+
+  final Order authorId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Author].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AuthorPageRequest implements PageRequest<Author, AuthorCursor> {
+  const AuthorPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AuthorDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AuthorCursor? cursor;
+
+  final AuthorDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Author> author) => [
+    (author.authorId, direction.authorId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Author> author) =>
+      direction.authorId == Order.ascending
+      ? author.authorId > toExpr(cursor!.authorId)
+      : author.authorId < toExpr(cursor!.authorId);
+
+  @override
+  AuthorCursor cursorOf(Author author) =>
+      AuthorCursor(authorId: author.authorId);
+
+  @override
+  AuthorPageRequest withCursor(AuthorCursor cursor) => AuthorPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `authors` table.
 extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// Lookup a single row in `authors` table using the _primary key_.
@@ -182,6 +247,30 @@ extension QueryAuthorExt on Query<(Expr<Author>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Author>,)> byKey(int authorId) =>
       where((author) => author.authorId.equalsValue(authorId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Author, AuthorCursor>? request =
+  ///     AuthorPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AuthorCursor].
+  Future<Page<Author, AuthorCursor>> fetchPage(
+    PageRequest<Author, AuthorCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Author, AuthorCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `authors` table matching this [Query].
   ///
@@ -751,6 +840,66 @@ extension TableBookExt on Table<Book> {
       $ForGeneratedCode.deleteSingle(byKey(bookId), _$Book._$table);
 }
 
+/// Pagination cursor referencing a row in [Book].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class BookCursor {
+  const BookCursor({required this.bookId});
+
+  final int bookId;
+
+  @override
+  String toString() => 'BookCursor(bookId: "$bookId")';
+}
+
+/// Sort direction for each _primary key_ field of [Book], used by
+/// `.fetchPage(...)`.
+final class BookDirection {
+  const BookDirection({this.bookId = Order.ascending});
+
+  final Order bookId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Book].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class BookPageRequest implements PageRequest<Book, BookCursor> {
+  const BookPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const BookDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final BookCursor? cursor;
+
+  final BookDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Book> book) => [
+    (book.bookId, direction.bookId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Book> book) => direction.bookId == Order.ascending
+      ? book.bookId > toExpr(cursor!.bookId)
+      : book.bookId < toExpr(cursor!.bookId);
+
+  @override
+  BookCursor cursorOf(Book book) => BookCursor(bookId: book.bookId);
+
+  @override
+  BookPageRequest withCursor(BookCursor cursor) =>
+      BookPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `books` table.
 extension QueryBookExt on Query<(Expr<Book>,)> {
   /// Lookup a single row in `books` table using the _primary key_.
@@ -759,6 +908,30 @@ extension QueryBookExt on Query<(Expr<Book>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Book>,)> byKey(int bookId) =>
       where((book) => book.bookId.equalsValue(bookId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Book, BookCursor>? request =
+  ///     BookPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [BookCursor].
+  Future<Page<Book, BookCursor>> fetchPage(
+    PageRequest<Book, BookCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Book, BookCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `books` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/as_subquery_model/as_subquery_model_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
+++ b/typed_sql/test/typed_sql/subquery/exists_model/exists_model_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/key_conflict/key_conflict_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/nested_basic/nested_basic_test.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.g.dart
+++ b/typed_sql/test/typed_sql/transact/nested_complex/nested_complex_test.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
+++ b/typed_sql/test/typed_sql/types/datetime/datetime_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/composite_unique/composite_unique_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/composite_unique/composite_unique_test.g.dart
@@ -190,6 +190,66 @@ extension TableUserExt on Table<User> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$User._$table);
 }
 
+/// Pagination cursor referencing a row in [User].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class UserCursor {
+  const UserCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'UserCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [User], used by
+/// `.fetchPage(...)`.
+final class UserDirection {
+  const UserDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [User].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class UserPageRequest implements PageRequest<User, UserCursor> {
+  const UserPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const UserDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final UserCursor? cursor;
+
+  final UserDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<User> user) => [
+    (user.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<User> user) => direction.accountId == Order.ascending
+      ? user.accountId > toExpr(cursor!.accountId)
+      : user.accountId < toExpr(cursor!.accountId);
+
+  @override
+  UserCursor cursorOf(User user) => UserCursor(accountId: user.accountId);
+
+  @override
+  UserPageRequest withCursor(UserCursor cursor) =>
+      UserPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `users` table.
 extension QueryUserExt on Query<(Expr<User>,)> {
   /// Lookup a single row in `users` table using the _primary key_.
@@ -198,6 +258,30 @@ extension QueryUserExt on Query<(Expr<User>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<User>,)> byKey(int accountId) =>
       where((user) => user.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<User, UserCursor>? request =
+  ///     UserPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [UserCursor].
+  Future<Page<User, UserCursor>> fetchPage(
+    PageRequest<User, UserCursor> request,
+  ) => $ForGeneratedCode.fetchPage<User, UserCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `users` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_boolean/unique_boolean_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_boolean/unique_boolean_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_integer/unique_integer_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_integer/unique_integer_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_real/unique_real_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_real/unique_real_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_text/unique_text_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_text/unique_text_test.g.dart
@@ -161,6 +161,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -169,6 +229,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/types/unique_zero_real/unique_zero_real_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/types/unique_zero_real/unique_zero_real_test.g.dart
@@ -154,6 +154,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -162,6 +222,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_model/unique_model_test.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
+++ b/typed_sql/test/typed_sql/unique/unique_nullable/unique_nullable_test.g.dart
@@ -181,6 +181,71 @@ extension TableAccountExt on Table<Account> {
       $ForGeneratedCode.deleteSingle(byKey(accountId), _$Account._$table);
 }
 
+/// Pagination cursor referencing a row in [Account].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class AccountCursor {
+  const AccountCursor({required this.accountId});
+
+  final int accountId;
+
+  @override
+  String toString() => 'AccountCursor(accountId: "$accountId")';
+}
+
+/// Sort direction for each _primary key_ field of [Account], used by
+/// `.fetchPage(...)`.
+final class AccountDirection {
+  const AccountDirection({this.accountId = Order.ascending});
+
+  final Order accountId;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Account].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class AccountPageRequest implements PageRequest<Account, AccountCursor> {
+  const AccountPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const AccountDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final AccountCursor? cursor;
+
+  final AccountDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Account> account) => [
+    (account.accountId, direction.accountId),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Account> account) =>
+      direction.accountId == Order.ascending
+      ? account.accountId > toExpr(cursor!.accountId)
+      : account.accountId < toExpr(cursor!.accountId);
+
+  @override
+  AccountCursor cursorOf(Account account) =>
+      AccountCursor(accountId: account.accountId);
+
+  @override
+  AccountPageRequest withCursor(AccountCursor cursor) => AccountPageRequest(
+    pageSize: pageSize,
+    cursor: cursor,
+    direction: direction,
+  );
+}
+
 /// Extension methods for building queries against the `accounts` table.
 extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// Lookup a single row in `accounts` table using the _primary key_.
@@ -189,6 +254,30 @@ extension QueryAccountExt on Query<(Expr<Account>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Account>,)> byKey(int accountId) =>
       where((account) => account.accountId.equalsValue(accountId)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Account, AccountCursor>? request =
+  ///     AccountPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [AccountCursor].
+  Future<Page<Account, AccountCursor>> fetchPage(
+    PageRequest<Account, AccountCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Account, AccountCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `accounts` table matching this [Query].
   ///

--- a/typed_sql/test/typed_sql/where/nullable_bool/nullable_bool_where_test.g.dart
+++ b/typed_sql/test/typed_sql/where/nullable_bool/nullable_bool_where_test.g.dart
@@ -149,6 +149,66 @@ extension TableItemExt on Table<Item> {
       $ForGeneratedCode.deleteSingle(byKey(id), _$Item._$table);
 }
 
+/// Pagination cursor referencing a row in [Item].
+///
+/// This identifies the row after which the next page of results begins,
+/// using the values of the _primary key_ fields from that row.
+final class ItemCursor {
+  const ItemCursor({required this.id});
+
+  final int id;
+
+  @override
+  String toString() => 'ItemCursor(id: "$id")';
+}
+
+/// Sort direction for each _primary key_ field of [Item], used by
+/// `.fetchPage(...)`.
+final class ItemDirection {
+  const ItemDirection({this.id = Order.ascending});
+
+  final Order id;
+}
+
+/// Parameters for a `.fetchPage(...)` call against [Item].
+///
+/// > [!WARNING]
+/// > Always use the same [direction] for every page in a single pagination.
+/// > Using a cursor obtained with one direction while fetching
+/// > with a different direction will paginate the wrong way.
+final class ItemPageRequest implements PageRequest<Item, ItemCursor> {
+  const ItemPageRequest({
+    required this.pageSize,
+    this.cursor,
+    this.direction = const ItemDirection(),
+  });
+
+  @override
+  final int pageSize;
+
+  @override
+  final ItemCursor? cursor;
+
+  final ItemDirection direction;
+
+  @override
+  List<(Expr<Comparable?>, Order)> orderBy(Expr<Item> item) => [
+    (item.id, direction.id),
+  ];
+
+  @override
+  Expr<bool?> where(Expr<Item> item) => direction.id == Order.ascending
+      ? item.id > toExpr(cursor!.id)
+      : item.id < toExpr(cursor!.id);
+
+  @override
+  ItemCursor cursorOf(Item item) => ItemCursor(id: item.id);
+
+  @override
+  ItemPageRequest withCursor(ItemCursor cursor) =>
+      ItemPageRequest(pageSize: pageSize, cursor: cursor, direction: direction);
+}
+
 /// Extension methods for building queries against the `items` table.
 extension QueryItemExt on Query<(Expr<Item>,)> {
   /// Lookup a single row in `items` table using the _primary key_.
@@ -157,6 +217,30 @@ extension QueryItemExt on Query<(Expr<Item>,)> {
   /// when `.fetch()` is called.
   QuerySingle<(Expr<Item>,)> byKey(int id) =>
       where((item) => item.id.equalsValue(id)).first;
+
+  /// Fetch a page of at most `request.pageSize` rows.
+  ///
+  /// For continuing an existing pagination, pass `page.nextPageRequest`
+  /// from the previous page as [request]:
+  /// ```dart
+  /// PageRequest<Item, ItemCursor>? request =
+  ///     ItemPageRequest(pageSize: 100);
+  /// while (request != null) {
+  ///   final page = await db.myTable.fetchPage(request);
+  ///   // ... process page.items ...
+  ///   request = page.nextPageRequest;
+  /// }
+  /// ```
+  ///
+  /// If you only need a resume point to persist (e.g. in a URL or a stored
+  /// checkpoint) rather than the whole request, use `page.nextCursor`
+  /// instead -- see [ItemCursor].
+  Future<Page<Item, ItemCursor>> fetchPage(
+    PageRequest<Item, ItemCursor> request,
+  ) => $ForGeneratedCode.fetchPage<Item, ItemCursor>(
+    query: this,
+    request: request,
+  );
 
   /// Update all rows in the `items` table matching this [Query].
   ///


### PR DESCRIPTION
I'm not 100% about the design, but I think this is a good direction, so I'll just stop here for comments and discussion.

Some things to consider now or even later:
- selecting only parts of the row object (e.g. PKs + some columns)
- using cursor columns semi-automatically (e.g. generic pagination that is not PK-based - unique works, or row skips need to be tolerated)
- extracting cursor ordering automatically (e.g. storing on the `ORDER BY` clause)
- merging the cursor value fields with the direction fields
- better hiding the generated parts of the API (except cursor + directionality + next request logic)
- generic extension method: `Stream<Row>` iteration over pagination, e.g. `streamPages(PageRequest)` method with optional `limit`

WDYT?